### PR TITLE
Improve teammate health checks with runtime readiness telemetry

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -146,8 +146,13 @@ Check if a teammate is still running or has unread messages.
 - `agent_name` (required): Name of the teammate to check
 
 **Returns**: Status information including:
-- Whether the teammate is still running
-- Number of unread messages
+- `alive`: Whether the teammate process/pane/window is still running
+- `unreadCount`: Number of unread inbox messages
+- `health`: One of `healthy`, `idle`, `starting`, `stalled`, `dead`
+- `agentLoopReady`: Whether the teammate has executed its inbox-read loop at least once
+- `hasRecentHeartbeat`: Whether heartbeat data has been updated recently
+- `startupStalled`: Detects the "alive but not consuming inbox" startup failure mode
+- `runtime`: Raw runtime telemetry (timestamps, pid, last error)
 
 **Example**:
 ```javascript

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -32,6 +32,10 @@ export function inboxPath(teamName: string, agentName: string) {
   return path.join(teamDir(teamName), "inboxes", `${sanitizeName(agentName)}.json`);
 }
 
+export function runtimeStatusPath(teamName: string, agentName: string) {
+  return path.join(teamDir(teamName), "runtime", `${sanitizeName(agentName)}.json`);
+}
+
 export function configPath(teamName: string) {
   return path.join(teamDir(teamName), "config.json");
 }

--- a/src/utils/runtime.test.ts
+++ b/src/utils/runtime.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { writeRuntimeStatus, readRuntimeStatus } from "./runtime";
+import { runtimeStatusPath, teamDir } from "./paths";
+
+describe("runtime status", () => {
+  const teamName = `runtime-test-${Date.now()}`;
+  const agentName = "worker-1";
+
+  beforeEach(() => {
+    const dir = teamDir(teamName);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    const dir = teamDir(teamName);
+    if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes and reads status", async () => {
+    await writeRuntimeStatus(teamName, agentName, {
+      pid: 123,
+      startedAt: 1000,
+      ready: false,
+    });
+
+    const runtime = await readRuntimeStatus(teamName, agentName);
+    expect(runtime).not.toBeNull();
+    expect(runtime?.teamName).toBe(teamName);
+    expect(runtime?.agentName).toBe(agentName);
+    expect(runtime?.pid).toBe(123);
+    expect(runtime?.ready).toBe(false);
+  });
+
+  it("merges updates instead of overwriting status", async () => {
+    await writeRuntimeStatus(teamName, agentName, {
+      pid: 123,
+      startedAt: 1000,
+      ready: false,
+    });
+
+    await writeRuntimeStatus(teamName, agentName, {
+      lastHeartbeatAt: 2000,
+      ready: true,
+    });
+
+    const runtime = await readRuntimeStatus(teamName, agentName);
+    expect(runtime?.pid).toBe(123);
+    expect(runtime?.startedAt).toBe(1000);
+    expect(runtime?.lastHeartbeatAt).toBe(2000);
+    expect(runtime?.ready).toBe(true);
+  });
+
+  it("returns null when status does not exist", async () => {
+    const missing = await readRuntimeStatus(teamName, "missing-agent");
+    expect(missing).toBeNull();
+  });
+
+  it("stores status in team runtime directory", async () => {
+    await writeRuntimeStatus(teamName, agentName, { ready: true });
+    const p = runtimeStatusPath(teamName, agentName);
+    expect(path.basename(path.dirname(p))).toBe("runtime");
+    expect(fs.existsSync(p)).toBe(true);
+  });
+});

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { withLock } from "./lock";
+import { runtimeStatusPath } from "./paths";
+
+export interface AgentRuntimeStatus {
+  teamName: string;
+  agentName: string;
+  pid?: number;
+  startedAt?: number;
+  lastHeartbeatAt?: number;
+  lastInboxReadAt?: number;
+  ready?: boolean;
+  lastError?: string;
+}
+
+export async function writeRuntimeStatus(
+  teamName: string,
+  agentName: string,
+  updates: Partial<AgentRuntimeStatus>
+): Promise<AgentRuntimeStatus> {
+  const p = runtimeStatusPath(teamName, agentName);
+  const dir = path.dirname(p);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  return await withLock(p, async () => {
+    let current: AgentRuntimeStatus = {
+      teamName,
+      agentName,
+    };
+
+    if (fs.existsSync(p)) {
+      current = JSON.parse(fs.readFileSync(p, "utf-8")) as AgentRuntimeStatus;
+    }
+
+    const next: AgentRuntimeStatus = {
+      ...current,
+      ...updates,
+      teamName,
+      agentName,
+    };
+
+    fs.writeFileSync(p, JSON.stringify(next, null, 2));
+    return next;
+  });
+}
+
+export async function readRuntimeStatus(
+  teamName: string,
+  agentName: string
+): Promise<AgentRuntimeStatus | null> {
+  const p = runtimeStatusPath(teamName, agentName);
+  if (!fs.existsSync(p)) return null;
+
+  return await withLock(p, async () => {
+    if (!fs.existsSync(p)) return null;
+    return JSON.parse(fs.readFileSync(p, "utf-8")) as AgentRuntimeStatus;
+  });
+}


### PR DESCRIPTION
## Summary

This PR fixes an intermittent `pi-teams` failure mode where a teammate appears `alive: true` but does not consume inbox messages during bootstrap.

The core issue is that `check_teammate` previously measured terminal process/pane liveness only, which can diverge from actual agent-loop readiness.

## Problem

Observed behavior in the field:

- teammate pane/process reported as alive
- `unreadCount` kept increasing
- no READY acknowledgement or inbox consumption
- retrying with a freshly spawned teammate often worked immediately

This creates false confidence and forces manual troubleshooting/retry loops.

## Root cause addressed

`check_teammate` lacked runtime-level telemetry. It could only tell "pane exists" and "messages are unread", but not whether the teammate loop had initialized and was actually polling/processing.

## What changed

### 1) Runtime telemetry per teammate
Added persistent runtime status files:

`~/.pi/teams/<team>/runtime/<agent>.json`

New status payload includes:

- `pid`
- `startedAt`
- `lastHeartbeatAt`
- `lastInboxReadAt`
- `ready`
- `lastError`

### 2) Heartbeat + readiness updates
Teammates now update runtime status at key points:

- on session start (`ready=false`, startup metadata)
- on turn start (heartbeat)
- on idle polling loop (heartbeat + error capture)
- on successful self `read_inbox` (marks `ready=true`, updates `lastInboxReadAt`)

### 3) Better health reporting in `check_teammate`
`check_teammate` now returns richer diagnostics while preserving backward compatibility (`alive`, `unreadCount`):

- `health`: `healthy | idle | starting | stalled | dead`
- `agentLoopReady`
- `hasRecentHeartbeat`
- `startupStalled`
- `runtime` (raw telemetry)

This explicitly detects the "alive but not consuming inbox" startup stall pattern.

### 4) Runtime cleanup
When a teammate is killed/shutdown, its runtime status file is removed.

### 5) Documentation + tests
- Updated `docs/reference.md` for new `check_teammate` response semantics.
- Added `src/utils/runtime.test.ts` for runtime status read/write/merge behavior.

## Validation

Executed test suite:

- `npm test --silent` ✅ (all tests passing)

## Impact

- Improves first-spawn reliability diagnostics
- Reduces false positives from pane-only liveness checks
- Gives deterministic signal for readiness gates and auto-recovery workflows
- Makes teammate bootstrap failures actionable instead of silent
