### PR TITLE
fix(tmux): target the originating pane/window when spawning

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -378,11 +378,17 @@ export default function (pi: ExtensionAPI) {
             }
           }
 
+          const leadMember = teamConfig.members.find(m => m.name === "team-lead");
+          const anchorPaneId = terminal.name === "tmux"
+            ? leadMember?.tmuxPaneId || process.env.TMUX_PANE || undefined
+            : undefined;
+
           terminalId = terminal.spawn({
             name: safeName,
             cwd: params.cwd,
             command: piCmd,
             env: env,
+            anchorPaneId,
           });
           await teams.updateMember(safeTeamName, safeName, { tmuxPaneId: terminalId });
         }

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -38,7 +38,17 @@ describe("TmuxAdapter", () => {
   });
 
   it("should target the originating pane and its window when spawning", () => {
-    mockExecCommand.mockImplementation((_bin, args) => {
+    mockExecCommand.mockImplementation((_bin: string, args: string[]) => {
+      if (
+        args[0] === "display-message" &&
+        args[1] === "-p" &&
+        args[2] === "-t" &&
+        args[3] === "%16" &&
+        args[4] === "#{pane_id}"
+      ) {
+        return { stdout: "%16", stderr: "", status: 0 };
+      }
+
       if (args[0] === "split-window") {
         return { stdout: "%42", stderr: "", status: 0 };
       }
@@ -47,7 +57,7 @@ describe("TmuxAdapter", () => {
         args[0] === "display-message" &&
         args[1] === "-p" &&
         args[2] === "-t" &&
-        args[3] === "%42" &&
+        args[3] === "%16" &&
         args[4] === "#{window_id}"
       ) {
         return { stdout: "@7", stderr: "", status: 0 };
@@ -83,6 +93,128 @@ describe("TmuxAdapter", () => {
     expect(mockExecCommand).toHaveBeenCalledWith(
       "tmux",
       ["select-layout", "-t", "@7", "main-vertical"]
+    );
+  });
+
+  it("should prefer an explicit anchor pane when spawning", () => {
+    mockExecCommand.mockImplementation((_bin: string, args: string[]) => {
+      if (
+        args[0] === "display-message" &&
+        args[1] === "-p" &&
+        args[2] === "-t" &&
+        args[3] === "%3" &&
+        args[4] === "#{pane_id}"
+      ) {
+        return { stdout: "%3", stderr: "", status: 0 };
+      }
+
+      if (args[0] === "split-window") {
+        return { stdout: "%42", stderr: "", status: 0 };
+      }
+
+      if (
+        args[0] === "display-message" &&
+        args[1] === "-p" &&
+        args[2] === "-t" &&
+        args[3] === "%3" &&
+        args[4] === "#{window_id}"
+      ) {
+        return { stdout: "@9", stderr: "", status: 0 };
+      }
+
+      return { stdout: "", stderr: "", status: 0 };
+    });
+
+    const paneId = adapter.spawn({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi",
+      env: { PI_TEAM_NAME: "team-1", PI_AGENT_NAME: "agent-1" },
+      anchorPaneId: "%3",
+    });
+
+    expect(paneId).toBe("%42");
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "tmux",
+      [
+        "split-window",
+        "-h", "-dP",
+        "-F", "#{pane_id}",
+        "-t", "%3",
+        "-c", "/tmp/project",
+        "env", "PI_TEAM_NAME=team-1", "PI_AGENT_NAME=agent-1",
+        "sh", "-c", "pi",
+      ]
+    );
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "tmux",
+      ["set-window-option", "-t", "@9", "main-pane-width", "60%"]
+    );
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "tmux",
+      ["select-layout", "-t", "@9", "main-vertical"]
+    );
+  });
+
+  it("should fall back to the current pane when the explicit anchor is stale", () => {
+    mockExecCommand.mockImplementation((_bin: string, args: string[]) => {
+      if (
+        args[0] === "display-message" &&
+        args[1] === "-p" &&
+        args[2] === "-t" &&
+        args[3] === "%3" &&
+        args[4] === "#{pane_id}"
+      ) {
+        return { stdout: "", stderr: "no such pane", status: 1 };
+      }
+
+      if (
+        args[0] === "display-message" &&
+        args[1] === "-p" &&
+        args[2] === "-t" &&
+        args[3] === "%16" &&
+        args[4] === "#{pane_id}"
+      ) {
+        return { stdout: "%16", stderr: "", status: 0 };
+      }
+
+      if (args[0] === "split-window") {
+        return { stdout: "%42", stderr: "", status: 0 };
+      }
+
+      if (
+        args[0] === "display-message" &&
+        args[1] === "-p" &&
+        args[2] === "-t" &&
+        args[3] === "%16" &&
+        args[4] === "#{window_id}"
+      ) {
+        return { stdout: "@7", stderr: "", status: 0 };
+      }
+
+      return { stdout: "", stderr: "", status: 0 };
+    });
+
+    const paneId = adapter.spawn({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi",
+      env: { PI_TEAM_NAME: "team-1", PI_AGENT_NAME: "agent-1" },
+      anchorPaneId: "%3",
+    });
+
+    expect(paneId).toBe("%42");
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "tmux",
+      [
+        "split-window",
+        "-h", "-dP",
+        "-F", "#{pane_id}",
+        "-t", "%16",
+        "-c", "/tmp/project",
+        "env", "PI_TEAM_NAME=team-1", "PI_AGENT_NAME=agent-1",
+        "sh", "-c", "pi",
+      ]
     );
   });
 

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -34,12 +34,36 @@ export class TmuxAdapter implements TerminalAdapter {
     }
   }
 
+  private isPaneUsable(paneId: string | null | undefined): paneId is string {
+    if (!paneId) return false;
+
+    try {
+      const result = execCommand("tmux", ["display-message", "-p", "-t", paneId, "#{pane_id}"]);
+      return result.status === 0 && result.stdout.trim() === paneId;
+    } catch {
+      return false;
+    }
+  }
+
+  private getOriginPaneId(preferredPaneId?: string | null): string | null {
+    if (this.isPaneUsable(preferredPaneId)) {
+      return preferredPaneId;
+    }
+
+    const currentPaneId = this.getCurrentPaneId();
+    if (this.isPaneUsable(currentPaneId)) {
+      return currentPaneId;
+    }
+
+    return null;
+  }
+
   spawn(options: SpawnOptions): string {
     const envArgs = Object.entries(options.env)
       .filter(([k]) => k.startsWith("PI_"))
       .map(([k, v]) => `${k}=${v}`);
 
-    const originPaneId = this.getCurrentPaneId();
+    const originPaneId = this.getOriginPaneId(options.anchorPaneId);
     const tmuxArgs = [
       "split-window",
       "-h", "-dP",
@@ -63,10 +87,10 @@ export class TmuxAdapter implements TerminalAdapter {
     }
 
     const newPaneId = result.stdout.trim();
-    const layoutTarget = this.getWindowIdForPane(newPaneId) ?? this.getWindowIdForPane(originPaneId);
+    const layoutTarget = this.getWindowIdForPane(originPaneId) ?? this.getWindowIdForPane(newPaneId);
 
     // Apply layout to the exact window that contains the spawned pane so the
-    // split always stays anchored to the originating tmux window.
+    // split always stays anchored to the intended tmux window.
     if (layoutTarget) {
       execCommand("tmux", ["set-window-option", "-t", layoutTarget, "main-pane-width", "60%"]);
       execCommand("tmux", ["select-layout", "-t", layoutTarget, "main-vertical"]);

--- a/src/utils/terminal-adapter.ts
+++ b/src/utils/terminal-adapter.ts
@@ -21,6 +21,8 @@ export interface SpawnOptions {
   env: Record<string, string>;
   /** Team name for window title formatting (e.g., "team: agent") */
   teamName?: string;
+  /** Optional pane ID to anchor pane-based layouts to a specific origin pane */
+  anchorPaneId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix tmux teammate spawning so new panes stay attached to the pane/window that originated the spawn.

## Problem

`TmuxAdapter.spawn()` currently runs `tmux split-window` without `-t`.

When the active tmux client has switched to a different window, tmux resolves the split against that *current* client context instead of the pane where the pi-teams agent is running. This can cause teammates to appear in a different tmux window than the one that requested them.

## Changes

- read the originating pane from `TMUX_PANE`
- pass `-t <origin-pane>` to `tmux split-window`
- resolve the spawned pane's `window_id` and target layout commands at that exact window
- target `setTitle()` at the current pane explicitly as well
- add `src/adapters/tmux-adapter.test.ts`

## Validation

Passed:
- `npm test -- src/adapters/tmux-adapter.test.ts`
- `tsc --noEmit --target es2022 --module nodenext --moduleResolution nodenext src/utils/terminal-adapter.ts src/adapters/tmux-adapter.ts src/adapters/tmux-adapter.test.ts`

Note:
- `npm test` still shows pre-existing failures in `src/adapters/windows-adapter.test.ts` unrelated to this change.
