### PR TITLE
fix: register CmuxAdapter in terminal registry

### DIFF
--- a/src/adapters/terminal-registry.ts
+++ b/src/adapters/terminal-registry.ts
@@ -7,8 +7,9 @@
 
 import { TerminalAdapter } from "../utils/terminal-adapter";
 import { TmuxAdapter } from "./tmux-adapter";
-import { Iterm2Adapter } from "./iterm2-adapter";
 import { ZellijAdapter } from "./zellij-adapter";
+import { CmuxAdapter } from "./cmux-adapter";
+import { Iterm2Adapter } from "./iterm2-adapter";
 import { WezTermAdapter } from "./wezterm-adapter";
 import { WindowsAdapter } from "./windows-adapter";
 
@@ -18,13 +19,15 @@ import { WindowsAdapter } from "./windows-adapter";
  * Detection order (first match wins):
  * 1. tmux - if TMUX env is set
  * 2. Zellij - if ZELLIJ env is set and not in tmux
- * 3. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij
- * 4. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij
- * 5. Windows - if platform is win32 and not in tmux/zellij/iTerm2/WezTerm
+ * 3. cmux - if CMUX_SOCKET_PATH or CMUX_WORKSPACE_ID env is set
+ * 4. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij/cmux
+ * 5. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij/cmux
+ * 6. Windows - if platform is win32 and not in tmux/zellij/cmux/iTerm2/WezTerm
  */
 const adapters: TerminalAdapter[] = [
   new TmuxAdapter(),
   new ZellijAdapter(),
+  new CmuxAdapter(),
   new Iterm2Adapter(),
   new WezTermAdapter(),
   new WindowsAdapter(),
@@ -41,9 +44,10 @@ let cachedAdapter: TerminalAdapter | null = null;
  * Detection order (first match wins):
  * 1. tmux - if TMUX env is set
  * 2. Zellij - if ZELLIJ env is set and not in tmux
- * 3. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij
- * 4. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij
- * 5. Windows - if platform is win32 and not in tmux/zellij/iTerm2/WezTerm
+ * 3. cmux - if CMUX_SOCKET_PATH or CMUX_WORKSPACE_ID env is set
+ * 4. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij/cmux
+ * 5. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij/cmux
+ * 6. Windows - if platform is win32 and not in tmux/zellij/cmux/iTerm2/WezTerm
  *
  * @returns The detected terminal adapter, or null if none detected
  */
@@ -65,7 +69,7 @@ export function getTerminalAdapter(): TerminalAdapter | null {
 /**
  * Get a specific terminal adapter by name.
  *
- * @param name - The adapter name (e.g., "tmux", "iTerm2", "zellij", "WezTerm", "Windows")
+ * @param name - The adapter name (e.g., "tmux", "zellij", "cmux", "iTerm2", "WezTerm", "Windows")
  * @returns The adapter instance, or undefined if not found
  */
 export function getAdapterByName(name: string): TerminalAdapter | undefined {
@@ -107,7 +111,7 @@ export function hasTerminalAdapter(): boolean {
 /**
  * Check if the current terminal supports spawning separate OS windows.
  *
- * @returns true if the detected terminal supports windows (iTerm2, WezTerm, Windows)
+ * @returns true if the detected terminal supports windows (iTerm2, WezTerm, Windows, cmux)
  */
 export function supportsWindows(): boolean {
   const adapter = getTerminalAdapter();


### PR DESCRIPTION
## Problem

The `CmuxAdapter` was implemented in `src/adapters/cmux-adapter.ts` but was never registered in the terminal registry, preventing pi-teams from working with the cmux terminal multiplexer.

## Solution

This PR adds the `CmuxAdapter` import and registers it in the adapters array with the correct priority order.

### Changes

1. Added import for `CmuxAdapter`
2. Registered `CmuxAdapter` in the adapters array (after tmux/Zellij, before iTerm2)
3. Updated all documentation comments to include cmux in the detection order

### Detection Order (after this fix)

1. tmux - if TMUX env is set
2. Zellij - if ZELLIJ env is set and not in tmux
3. **cmux** - if CMUX_SOCKET_PATH or CMUX_WORKSPACE_ID env is set
4. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij/cmux
5. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij/cmux
6. Windows - if platform is win32 and not in tmux/zellij/cmux/iTerm2/WezTerm

### Testing

The CmuxAdapter detection uses `CMUX_SOCKET_PATH` or `CMUX_WORKSPACE_ID` environment variables, which are automatically set when running inside cmux.