### PR TITLE
Fix teammate spawning on shim-based pi installs

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -18,23 +18,36 @@ import { spawnSync } from "node:child_process";
 /**
  * Build the command used to relaunch pi for teammate processes.
  *
- * In Bun-compiled pi binaries, process.argv[1] points at a virtual $bunfs path
- * like /$bunfs/root/pi, which is not a real file and breaks when prefixed with
- * `node`. process.execPath points at the actual executable in both compiled and
- * regular environments, so prefer that when available.
+ * There are three common cases:
+ * - npm/node install: pi runs as `node .../dist/cli.js`
+ * - standalone compiled binary: process.execPath is the actual `pi` executable
+ * - shim-based installs (e.g. Volta): process.execPath is `node` and argv[1]
+ *   may be a shim path, so the safest relaunch command is plain `pi`
  */
 function getPiLaunchCommand(): string {
-  // If we have an execPath, use it directly (works for both compiled binaries and node scripts)
-  if (process.execPath) {
-    return JSON.stringify(process.execPath);
+  const argv1 = process.argv[1];
+  const execPath = process.execPath;
+
+  // Regular Node install: relaunch the actual CLI script with node.
+  if (argv1) {
+    const ext = path.extname(argv1).toLowerCase();
+    const looksLikeScript = [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"].includes(ext)
+      || /(?:^|[/\\])dist[/\\]cli\.js$/i.test(argv1);
+
+    if (looksLikeScript) {
+      return `node ${JSON.stringify(argv1)}`;
+    }
   }
 
-  // Fallback: try argv[1] with node prefix for regular node environments
-  if (process.argv[1]) {
-    return `node ${JSON.stringify(process.argv[1])}`;
+  // Standalone binary install: execPath is the pi executable itself.
+  if (execPath) {
+    const base = path.basename(execPath).toLowerCase();
+    if (base !== "node" && base !== "node.exe" && base !== "bun" && base !== "bun.exe") {
+      return JSON.stringify(execPath);
+    }
   }
 
-  // Last resort: just use "pi" and hope it's on PATH
+  // Shim-based installs (like Volta) are safest to relaunch through PATH.
   return "pi";
 }
 


### PR DESCRIPTION
## Summary
Fix teammate process launching when `pi` is installed through a shim-based toolchain such as Volta.

## Problem
`getPiLaunchCommand()` currently prefers `process.execPath` when constructing the command used to start teammate sessions.

That works for standalone compiled binaries, but it breaks in shim-based installs:

- `process.execPath` points to `node`
- `process.argv[1]` can point to a shim path rather than the real Pi CLI script
- teammate spawning then runs `node --model ...`
- Node exits immediately with `node: bad option --model`

In my local setup this reproduced consistently when spawning teammates in iTerm tabs/windows.

## Fix
Update `getPiLaunchCommand()` to distinguish between three cases:

1. **Regular Node/npm install** → if `argv[1]` looks like a real CLI script, relaunch with `node <script>`
2. **Standalone binary install** → if `execPath` is not `node`/`bun`, use it directly
3. **Shim-based installs (Volta, similar)** → fall back to plain `pi` from `PATH`

This keeps the existing behavior for script and binary installs, while avoiding the broken `node --model ...` path on shim-based setups.

## Testing
- `npm test`
- manual smoke test against a local `pi-teams` install in a Volta-based Pi environment:
  - before: teammate tabs opened and immediately failed with `node: bad option --model`
  - after: teammate started successfully, became healthy, and processed inbox messages normally
