### PR TITLE
Allow xhigh thinking for spawn_teammate

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -106,7 +106,7 @@ After db-migrator completes, broadcast the schema change:
 Use different models for cost optimization:
 
 > **You:** "Create a team named 'mixed-speed' using 'gpt-4o'"
-> **You:** "Spawn a teammate named 'architect' using 'gpt-4o' with 'high' thinking level for design decisions"
+> **You:** "Spawn a teammate named 'architect' using 'gpt-4o' with 'xhigh' thinking level for design decisions"
 > **You:** "Spawn a teammate named 'implementer' using 'haiku' with 'low' thinking level for quick coding"
 > **You:** "Spawn a teammate named 'reviewer' using 'gpt-4o' with 'medium' thinking level for code reviews"
 
@@ -212,18 +212,20 @@ fi
 - **`low`** - Standard work: typical feature implementation, tests
 - **`medium`** - Complex work: architecture decisions, tricky bugs
 - **`high`** - Critical work: security reviews, major refactors, design specs
+- **`xhigh`** - Deepest available reasoning: architecture audits, thorny debugging, high-stakes review work
 
 ### 2. Team Composition
 
 Balanced teams typically include:
 - **1-2 high-thinking, high-model** agents for architecture and reviews
+- **Use `xhigh` sparingly** for the one teammate doing the hardest reasoning-heavy work
 - **2-3 low-thinking, fast-model** agents for implementation
 - **1 medium-thinking** agent for coordination
 
 Example:
 ```bash
 # Design/Review duo (expensive but thorough)
-spawn "architect" using "gpt-4o" with "high" thinking
+spawn "architect" using "gpt-4o" with "xhigh" thinking
 spawn "reviewer" using "gpt-4o" with "medium" thinking
 
 # Implementation trio (fast and cheap)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -82,7 +82,7 @@ Launch a new agent into a terminal pane with a role and instructions.
 - `prompt` (required): Instructions for the teammate's role and initial task
 - `cwd` (required): Working directory for the teammate
 - `model` (optional): AI model for this teammate (overrides team default)
-- `thinking` (optional): Thinking level (`off`, `minimal`, `low`, `medium`, `high`)
+- `thinking` (optional): Thinking level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`)
 - `plan_mode_required` (optional): If `true`, teammate must submit plans for approval
 
 **Model Options**:
@@ -95,6 +95,7 @@ Launch a new agent into a terminal pane with a role and instructions.
 - `low`: Light reasoning for quick decisions
 - `medium`: Balanced reasoning (default)
 - `high`: Extended reasoning for complex problems
+- `xhigh`: Maximum available reasoning for the hardest tasks
 
 **Examples**:
 ```javascript
@@ -131,7 +132,7 @@ spawn_teammate({
   prompt: "Design the new feature architecture",
   cwd: "/path/to/project",
   model: "gpt-4o",
-  thinking: "high"
+  thinking: "xhigh"
 })
 ```
 
@@ -577,7 +578,7 @@ pi-teams respects the following environment variables:
 
 - `ZELLIJ`: Automatically detected when running inside Zellij. Enables Zellij pane management.
 - `TMUX`: Automatically detected when running inside tmux. Enables tmux pane management.
-- `PI_DEFAULT_THINKING_LEVEL`: Default thinking level for spawned teammates if not specified (`off`, `minimal`, `low`, `medium`, `high`).
+- `PI_DEFAULT_THINKING_LEVEL`: Default thinking level for spawned teammates if not specified (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`).
 
 ---
 

--- a/docs/test-0.7.0.md
+++ b/docs/test-0.7.0.md
@@ -13,7 +13,7 @@ Test the new thinking parameter by spawning three teammates with different setti
 
 Prompt:
 "Spawn three teammates with different thinking levels:
-- 'DeepThinker' with 'high' thinking level. Tell them they are an expert at complex architectural analysis.
+- 'DeepThinker' with 'xhigh' thinking level. Tell them they are an expert at complex architectural analysis.
 - 'MediumBot' with 'medium' thinking level. Tell them they are a balanced worker.
 - 'FastWorker' with 'low' thinking level. Tell them they need to work quickly."
 
@@ -24,7 +24,7 @@ Prompt:
 Check that the thinking levels are correctly persisted in the team configuration.
 
 Prompt:
-"Read the config for the 'v070-test' team. Verify that DeepThinker has thinking level 'high', MediumBot has 'medium', and FastWorker has 'low'."
+"Read the config for the 'v070-test' team. Verify that DeepThinker has thinking level 'xhigh', MediumBot has 'medium', and FastWorker has 'low'."
 
 ---
 
@@ -70,10 +70,10 @@ Tell both to report their current thinking setting when they reply."
 
 ### 8. Verify All Thinking Levels Supported
 
-Check the team config again to ensure all five thinking levels are represented correctly.
+Check the team config again to ensure all six thinking levels are represented correctly.
 
 Prompt:
-"Read the team config again. Verify that DeepThinker shows 'high', MediumBot shows 'medium', FastWorker shows 'low', MinimalRunner shows 'minimal', and InstantRunner shows 'off'."
+"Spawn one more teammate named 'ReviewerMax' with 'high' thinking level using model 'google/gemini-2.0-flash'. Then read the team config again. Verify that DeepThinker shows 'xhigh', ReviewerMax shows 'high', MediumBot shows 'medium', FastWorker shows 'low', MinimalRunner shows 'minimal', and InstantRunner shows 'off'."
 
 ---
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -276,7 +276,7 @@ export default function (pi: ExtensionAPI) {
       prompt: Type.String(),
       cwd: Type.String(),
       model: Type.Optional(Type.String()),
-      thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high"])),
+      thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"])),
       plan_mode_required: Type.Optional(Type.Boolean({ default: false })),
       separate_window: Type.Optional(Type.Boolean({ default: false })),
     }),

--- a/src/utils/models.test.ts
+++ b/src/utils/models.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+import { THINKING_LEVELS } from "./models";
+
+describe("thinking levels", () => {
+  it("includes xhigh for teammate configuration", () => {
+    expect(THINKING_LEVELS).toContain("xhigh");
+  });
+});

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -1,3 +1,7 @@
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+
+export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
+
 export interface Member {
   agentId: string;
   name: string;
@@ -10,7 +14,7 @@ export interface Member {
   subscriptions: any[];
   prompt?: string;
   color?: string;
-  thinking?: "off" | "minimal" | "low" | "medium" | "high";
+  thinking?: ThinkingLevel;
   planModeRequired?: boolean;
   backendType?: string;
   isActive?: boolean;


### PR DESCRIPTION
## Why

`spawn_teammate` was capped at `high` even though the main `Agent` tool already exposes `xhigh`, and pi can pass thinking levels through directly on the CLI. That made teammate orchestration artificially less capable than standalone subagents for the exact kind of deep-review and architecture work teams often delegate.

In practice, this looked like a schema/docs mismatch rather than a runtime limitation: `spawn_teammate` already forwards the selected thinking value into `--model provider/model:thinking` or `--thinking`, so the missing piece was simply allowing `xhigh` through the teammate tool surface.

## How

- add `xhigh` to the `spawn_teammate` tool enum
- widen the persisted teammate `thinking` type to include `xhigh`
- add a small regression test covering the shared thinking-level list
- update the reference, guide, and test docs so they describe all supported teammate thinking levels consistently

## Validation

- `npx vitest run src/utils/models.test.ts src/utils/security.test.ts`
- full `npm test` still has pre-existing failures in `src/adapters/windows-adapter.test.ts` unrelated to this change (`Cannot find module '../utils/terminal-adapter'`)
