### PR TITLE
fix(cmux): use new-split + respawn-pane instead of unsupported --command flag

### DIFF
--- a/src/adapters/cmux-adapter.test.ts
+++ b/src/adapters/cmux-adapter.test.ts
@@ -62,12 +62,16 @@ describe("CmuxAdapter", () => {
       process.env.CMUX_SOCKET_PATH = "/tmp/cmux.sock";
     });
 
-    it("should spawn a new pane and return the surface ID", () => {
-      mockExecCommand.mockReturnValue({ 
-        stdout: "OK surface-42", 
-        stderr: "", 
-        status: 0 
-      });
+    it("should spawn via new-split + poll + respawn-pane and return the new surface", () => {
+      mockExecCommand
+        // 1. listSurfaceRefs (before snapshot) — realistic cmux output
+        .mockReturnValueOnce({ stdout: "* surface:1  Terminal  [selected]\n  surface:2  Terminal\n", stderr: "", status: 0 })
+        // 2. new-split right
+        .mockReturnValueOnce({ stdout: "OK", stderr: "", status: 0 })
+        // 3. listSurfaceRefs (poll — finds new surface:42)
+        .mockReturnValueOnce({ stdout: "* surface:1  Terminal  [selected]\n  surface:2  Terminal\n  surface:42  Terminal\n", stderr: "", status: 0 })
+        // 4. respawn-pane
+        .mockReturnValueOnce({ stdout: "OK", stderr: "", status: 0 });
 
       const result = adapter.spawn({
         name: "test-agent",
@@ -76,19 +80,25 @@ describe("CmuxAdapter", () => {
         env: { PI_AGENT_ID: "test-123" },
       });
 
-      expect(result).toBe("surface-42");
-      expect(mockExecCommand).toHaveBeenCalledWith(
-        "cmux",
-        ["new-split", "right", "--command", "env PI_AGENT_ID=test-123 pi --agent test"]
-      );
+      expect(result).toBe("surface:42");
+
+      // Verify new-split was called without --command
+      expect(mockExecCommand).toHaveBeenCalledWith("cmux", ["new-split", "right"]);
+
+      // Verify respawn-pane was called with the new surface and full command
+      expect(mockExecCommand).toHaveBeenCalledWith("cmux", [
+        "respawn-pane",
+        "--surface", "surface:42",
+        "--command", "env PI_AGENT_ID=test-123 pi --agent test",
+      ]);
     });
 
     it("should spawn without env prefix when no PI_ vars", () => {
-      mockExecCommand.mockReturnValue({ 
-        stdout: "OK surface-99", 
-        stderr: "", 
-        status: 0 
-      });
+      mockExecCommand
+        .mockReturnValueOnce({ stdout: "  surface:1  Terminal\n", stderr: "", status: 0 })
+        .mockReturnValueOnce({ stdout: "OK", stderr: "", status: 0 })
+        .mockReturnValueOnce({ stdout: "  surface:1  Terminal\n  surface:99  Terminal\n", stderr: "", status: 0 })
+        .mockReturnValueOnce({ stdout: "OK", stderr: "", status: 0 });
 
       const result = adapter.spawn({
         name: "test-agent",
@@ -97,19 +107,20 @@ describe("CmuxAdapter", () => {
         env: { OTHER: "ignored" },
       });
 
-      expect(result).toBe("surface-99");
-      expect(mockExecCommand).toHaveBeenCalledWith(
-        "cmux",
-        ["new-split", "right", "--command", "pi"]
-      );
+      expect(result).toBe("surface:99");
+      expect(mockExecCommand).toHaveBeenCalledWith("cmux", [
+        "respawn-pane",
+        "--surface", "surface:99",
+        "--command", "pi",
+      ]);
     });
 
-    it("should throw on spawn failure", () => {
-      mockExecCommand.mockReturnValue({ 
-        stdout: "", 
-        stderr: "cmux not found", 
-        status: 1 
-      });
+    it("should throw on new-split failure", () => {
+      mockExecCommand
+        // listSurfaceRefs (before)
+        .mockReturnValueOnce({ stdout: "  surface:1  Terminal\n", stderr: "", status: 0 })
+        // new-split fails
+        .mockReturnValueOnce({ stdout: "", stderr: "cmux not found", status: 1 });
 
       expect(() => adapter.spawn({
         name: "test-agent",
@@ -119,19 +130,43 @@ describe("CmuxAdapter", () => {
       })).toThrow("cmux new-split failed with status 1");
     });
 
-    it("should throw on unexpected output format", () => {
-      mockExecCommand.mockReturnValue({ 
-        stdout: "ERROR something went wrong", 
-        stderr: "", 
-        status: 0 
-      });
+    it("should throw when new surface is not found after polling", () => {
+      mockExecCommand
+        // listSurfaceRefs (before)
+        .mockReturnValueOnce({ stdout: "  surface:1  Terminal\n", stderr: "", status: 0 })
+        // new-split OK
+        .mockReturnValueOnce({ stdout: "OK", stderr: "", status: 0 });
+
+      // All subsequent polls return the same surfaces (no new one appears)
+      // Each poll cycle = listSurfaceRefs + sleep
+      for (let i = 0; i < 20; i++) {
+        mockExecCommand
+          .mockReturnValueOnce({ stdout: "  surface:1  Terminal\n", stderr: "", status: 0 })  // listSurfaceRefs
+          .mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });  // sleep
+      }
 
       expect(() => adapter.spawn({
         name: "test-agent",
         cwd: "/home/user/project",
         command: "pi",
         env: {},
-      })).toThrow("cmux new-split returned unexpected output");
+      })).toThrow("new surface was not found");
+    });
+
+    it("should throw when respawn-pane fails", () => {
+      mockExecCommand
+        .mockReturnValueOnce({ stdout: "  surface:1  Terminal\n", stderr: "", status: 0 })
+        .mockReturnValueOnce({ stdout: "OK", stderr: "", status: 0 })
+        .mockReturnValueOnce({ stdout: "  surface:1  Terminal\n  surface:50  Terminal\n", stderr: "", status: 0 })
+        // respawn-pane fails
+        .mockReturnValueOnce({ stdout: "", stderr: "respawn error", status: 1 });
+
+      expect(() => adapter.spawn({
+        name: "test-agent",
+        cwd: "/home/user/project",
+        command: "pi",
+        env: {},
+      })).toThrow("cmux respawn-pane failed with status 1");
     });
   });
 

--- a/src/adapters/cmux-adapter.ts
+++ b/src/adapters/cmux-adapter.ts
@@ -2,9 +2,19 @@
  * CMUX Terminal Adapter
  * 
  * Implements the TerminalAdapter interface for CMUX (cmux.dev).
+ *
+ * Spawn strategy: cmux's `new-split` does not support a `--command` flag.
+ * We follow the proven pattern from pi-cmux (npm:pi-cmux):
+ *   1. Snapshot existing surfaces
+ *   2. `cmux new-split <direction>`
+ *   3. Poll `cmux list-pane-surfaces` to find the newly created surface
+ *   4. `cmux respawn-pane --surface <id> --command <cmd>` to run the command
  */
 
 import { TerminalAdapter, SpawnOptions, execCommand } from "../utils/terminal-adapter";
+
+const SURFACE_POLL_ATTEMPTS = 20;
+const SURFACE_POLL_DELAY_MS = 150;
 
 export class CmuxAdapter implements TerminalAdapter {
   readonly name = "cmux";
@@ -18,34 +28,79 @@ export class CmuxAdapter implements TerminalAdapter {
     return !!process.env.CMUX_SOCKET_PATH || !!process.env.CMUX_WORKSPACE_ID;
   }
 
+  /**
+   * List all surface refs currently visible in the workspace.
+   */
+  private listSurfaceRefs(): Set<string> {
+    const refs = new Set<string>();
+    try {
+      const result = execCommand("cmux", ["list-pane-surfaces"]);
+      if (result.status === 0) {
+        for (const line of result.stdout.split("\n")) {
+          // Output lines look like: "* surface:5  ⠹ π · ziahmco  [selected]"
+          // Extract the surface:N ref from each line.
+          const match = line.match(/\b(surface:\d+)\b/);
+          if (match) refs.add(match[1]);
+        }
+      }
+    } catch {
+      // Ignore
+    }
+    return refs;
+  }
+
+  /**
+   * Block until a new surface appears that was not in `before`, or give up.
+   */
+  private waitForNewSurface(before: Set<string>): string | null {
+    for (let i = 0; i < SURFACE_POLL_ATTEMPTS; i++) {
+      const current = this.listSurfaceRefs();
+      for (const ref of current) {
+        if (!before.has(ref)) return ref;
+      }
+      // spawnSync-based sleep — keeps the adapter synchronous
+      execCommand("sleep", [String(SURFACE_POLL_DELAY_MS / 1000)]);
+    }
+    return null;
+  }
+
   spawn(options: SpawnOptions): string {
-    // We use new-split to create a new pane in CMUX.
-    // CMUX doesn't have a direct 'spawn' that returns a pane ID and runs a command 
-    // in one go while also returning the ID in a way we can easily capture for 'isAlive'.
-    // However, 'new-split' returns the new surface ID.
-    
-    // Construct the command with environment variables
+    // Construct the full command with PI_ environment variables
     const envPrefix = Object.entries(options.env)
       .filter(([k]) => k.startsWith("PI_"))
       .map(([k, v]) => `${k}=${v}`)
       .join(" ");
-    
+
     const fullCommand = envPrefix ? `env ${envPrefix} ${options.command}` : options.command;
 
-    // CMUX new-split returns "OK <UUID>"
-    const splitResult = execCommand("cmux", ["new-split", "right", "--command", fullCommand]);
-    
+    // 1. Snapshot existing surfaces before the split
+    const before = this.listSurfaceRefs();
+
+    // 2. Create the split (without --command, which is not supported)
+    const splitResult = execCommand("cmux", ["new-split", "right"]);
+
     if (splitResult.status !== 0) {
       throw new Error(`cmux new-split failed with status ${splitResult.status}: ${splitResult.stderr}`);
     }
 
-    const output = splitResult.stdout.trim();
-    if (output.startsWith("OK ")) {
-      const surfaceId = output.substring(3).trim();
-      return surfaceId;
+    // 3. Poll for the newly created surface
+    const newSurface = this.waitForNewSurface(before);
+    if (!newSurface) {
+      throw new Error("cmux new-split succeeded but new surface was not found");
     }
 
-    throw new Error(`cmux new-split returned unexpected output: ${output}`);
+    // 4. Use respawn-pane to run the command in the new surface
+    const respawnResult = execCommand("cmux", [
+      "respawn-pane",
+      "--surface", newSurface,
+      "--command", fullCommand,
+    ]);
+
+    if (respawnResult.status !== 0) {
+      throw new Error(`cmux respawn-pane failed with status ${respawnResult.status}: ${respawnResult.stderr}`);
+    }
+
+    return newSurface;
   }
 
   kill(paneId: string): void {


### PR DESCRIPTION
## Problem

cmux's `new-split` does not support a `--command` flag — the argument is silently ignored, leaving spawned panes as empty shells. This means **all pi-teams teammate spawning under cmux is broken**: the split is created but no `pi` process ever starts inside it.

Tested and confirmed: `cmux new-split right --command 'echo hello'` creates a pane that just sits at a shell prompt.

## Root Cause

The current `CmuxAdapter.spawn()` passes `--command` to `new-split`:

```ts
execCommand("cmux", ["new-split", "right", "--command", fullCommand]);
```

## Fix

Adopt the proven pattern from [pi-cmux](https://www.npmjs.com/package/pi-cmux) (`cmux-core.ts`):

1. Snapshot existing surfaces via `list-pane-surfaces`
2. `cmux new-split right` (no `--command`)
3. Poll `list-pane-surfaces` until a new surface appears
4. `cmux respawn-pane --surface <id> --command <cmd>` to run the command

This is the same strategy that pi-cmux uses successfully for its `/cmv`, `/cmh`, and `/cmo` split commands.

## Changes

- **`src/adapters/cmux-adapter.ts`** — Rewrote `spawn()` with the multi-step flow. Added `listSurfaceRefs()` and `waitForNewSurface()` private helpers.
- **`src/adapters/cmux-adapter.test.ts`** — Updated spawn tests to verify the new flow (snapshot → split → poll → respawn). Added tests for respawn failure and surface-not-found timeout.

## Testing

All 125 tests pass (13 test files), including the updated cmux adapter tests.