### PR TITLE
fix: prevent LLM from overriding pi's default model in subagents

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -521,7 +521,7 @@ export default function (pi: ExtensionAPI) {
     parameters: Type.Object({
       team_name: Type.String(),
       description: Type.Optional(Type.String()),
-      default_model: Type.Optional(Type.String()),
+      default_model: Type.Optional(Type.String({ description: "Default model for teammates. IMPORTANT: Omit this parameter to use pi's configured default model. Only set this when the user explicitly requests a specific model." })),
       separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
@@ -553,8 +553,9 @@ export default function (pi: ExtensionAPI) {
       name: Type.String(),
       prompt: Type.String(),
       cwd: Type.String(),
-      model: Type.Optional(Type.String()),
+      model: Type.Optional(Type.String({ description: "Model for this teammate. IMPORTANT: Omit this parameter to use pi's configured default model. Only set this when the user explicitly requests a specific model." })),
       thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"])),
+
       plan_mode_required: Type.Optional(Type.Boolean({ default: false })),
       separate_window: Type.Optional(Type.Boolean({ default: false })),
     }),
@@ -1102,7 +1103,7 @@ export default function (pi: ExtensionAPI) {
       team_name: Type.String({ description: "Name for the new team instance" }),
       predefined_team: Type.String({ description: "Name of the predefined team template from teams.yaml" }),
       cwd: Type.String({ description: "Working directory for spawned agents" }),
-      default_model: Type.Optional(Type.String({ description: "Default model for agents without a specified model" })),
+      default_model: Type.Optional(Type.String({ description: "Default model for agents without a specified model. IMPORTANT: Omit this parameter to use pi's configured default model. Only set this when the user explicitly requests a specific model." })),
       separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {


### PR DESCRIPTION
## Problem

When spawning teammates, the LLM (team lead) often passes `model: "sonnet"` (or similar) to `spawn_teammate` — even when the user never specified a model. This happens because the `model` parameter had no description instructing the LLM to omit it when not explicitly requested.

## Root Cause

1. `spawn_teammate`, `team_create`, and `create_predefined_team` had `model`/`default_model` parameters with **no description** — the LLM had no guidance on when (not) to set them.
2. `resolveModelWithProvider("sonnet")` resolves via `PROVIDER_PRIORITY` to `anthropic/sonnet` (anthropic is the first API-key provider in the list).
3. The subagent launches with `pi --model anthropic/sonnet`, **overriding pi's configured default model** (e.g. `zai/glm-5.1`).

## Fix

Added explicit descriptions to all three `model`/`default_model` parameters:

> **IMPORTANT: Omit this parameter to use pi's configured default model. Only set this when the user explicitly requests a specific model.**

This ensures the LLM only passes a model when the user explicitly asks for one — otherwise pi's own default is preserved.

## Affected Tools
- `team_create` (`default_model`)
- `spawn_teammate` (`model`)
- `create_predefined_team` (`default_model`)

## Testing
All 129 existing tests pass.