### PR TITLE
Replace smart model resolution with explicit model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,20 @@ pi install npm:pi-teams
 ## 🚀 Quick Start
 
 ```bash
-# 1. Start a team (inside tmux, Zellij, or iTerm2)
-"Create a team named 'my-team' using 'gpt-4o'"
+# 1. See available fully qualified models first
+"List available models for team creation"
 
-# 2. Spawn teammates
+# 2. Start a team (inside tmux, Zellij, or iTerm2)
+"Create a team named 'my-team' using 'openai-codex/gpt-5.4'"
+
+# 3. Spawn teammates
 "Spawn 'security-bot' to scan for vulnerabilities"
-"Spawn 'frontend-dev' using 'haiku' for quick iterations"
+"Spawn 'frontend-dev' using 'claude-agent-sdk/claude-sonnet-4-6' for quick iterations"
 
-# 3. Create and assign tasks
+# 4. Create and assign tasks
 "Create a task for security-bot: 'Audit auth endpoints'"
 
-# 4. Review and approve work
+# 5. Review and approve work
 "List all tasks and approve any pending plans"
 ```
 
@@ -57,17 +60,17 @@ pi install npm:pi-teams
 ## 💬 Key Examples
 
 ### 1. Start a Team
-> **You:** "Create a team named 'my-app-audit' for reviewing the codebase."
+> **You:** "List available models for team creation, then create a team named 'my-app-audit' using 'openai-codex/gpt-5.4' for reviewing the codebase."
 
 **Set a default model for the whole team:**
-> **You:** "Create a team named 'Research' and use 'gpt-4o' for everyone."
+> **You:** "List available models for team creation, then create a team named 'Research' using 'openai-codex/gpt-5.4' for everyone."
 
 **Start a team in "Separate Windows" mode:**
 > **You:** "Create a team named 'Dev' and open everyone in separate windows."
 *(Supported in iTerm2 and WezTerm only)*
 
 ### 2. Spawn Teammate with Custom Settings
-> **You:** "Spawn a teammate named 'security-bot' in the current folder. Tell them to scan for hardcoded API keys."
+> **You:** "Spawn a teammate named 'security-bot' using 'openai-codex/gpt-5.4' in the current folder. Tell them to scan for hardcoded API keys."
 
 **Spawn a specific teammate in a separate window:**
 > **You:** "Spawn 'researcher' in a separate window."
@@ -77,56 +80,36 @@ pi install npm:pi-teams
 *(Requires separate_windows mode enabled or iTerm2/WezTerm)*
 
 **Use a different model:**
-> **You:** "Spawn a teammate named 'speed-bot' using 'haiku' to quickly run some benchmarks."
+> **You:** "List available models for team creation, then spawn a teammate named 'speed-bot' using 'claude-agent-sdk/claude-sonnet-4-6' to quickly run some benchmarks."
 
 **Require plan approval:**
 > **You:** "Spawn a teammate named 'refactor-bot' and require plan approval before they make any changes."
 
 **Customize model and thinking level:**
-> **You:** "Spawn a teammate named 'architect-bot' using 'gpt-4o' with 'high' thinking level for deep reasoning."
+> **You:** "List available models for team creation, then spawn a teammate named 'architect-bot' using 'openai-codex/gpt-5.4' with 'high' thinking level for deep reasoning."
 
-**Smart Model Resolution:**
-When you specify a model name without a provider (e.g., `gemini-2.5-flash`), pi-teams automatically:
-- Queries available models from `pi --list-models`
-- Prioritizes **OAuth/subscription providers** (cheaper/free) over API-key providers:
-  - `google-gemini-cli` (OAuth) is preferred over `google` (API key)
-  - `github-copilot`, `kimi-sub` are preferred over their API-key equivalents
-- Falls back to API-key providers if OAuth providers aren't available
-- Constructs the correct `--model provider/model:thinking` command
+**Explicit model selection:**
+pi-teams does **not** auto-resolve bare model names like `gpt-5` or `haiku`.
+When creating a new team or spawning teammates, use `list_available_models` first and then pass a fully qualified `provider/model` string.
 
-> **Example:** Specifying `gemini-2.5-flash` will automatically use `google-gemini-cli/gemini-2.5-flash` if available, saving API costs.
+If you provide a model that is not fully qualified or not available, pi-teams will fail fast and ask you to choose a valid model.
 
-**Configuring provider resolution:**
-You can customize this behavior globally with `~/.pi/pi-teams.json` or per-project with `.pi/pi-teams.json`.
+**Configuring model-list ordering:**
+You can customize the order shown by `list_available_models` globally with `~/.pi/pi-teams.json` or per-project with `.pi/pi-teams.json`.
 Project-local config overrides global config.
 
 ```json
 {
   "providerPriority": [
-    "google-gemini-cli",
-    "github-copilot",
-    "kimi-sub",
-    "anthropic",
-    "openai",
-    "google",
-    "zai",
-    "azure-openai",
-    "amazon-bedrock",
-    "mistral",
-    "groq",
-    "cerebras",
-    "xai",
-    "vercel-ai-gateway",
-    "openrouter"
-  ],
-  "explicitOnlyProviders": ["openrouter"]
+    "openai-codex",
+    "claude-agent-sdk",
+    "kimi-coding"
+  ]
 }
 ```
 
-- `providerPriority`: Controls the order used when multiple providers match a bare model name.
-- `explicitOnlyProviders`: Providers that are ignored for bare model names and only used when you explicitly specify `provider/model`.
-
-> **Example:** With `"explicitOnlyProviders": ["openrouter"]`, `model: "gpt-5"` will not resolve to OpenRouter unless you explicitly use `openrouter/gpt-5`.
+- `providerPriority`: Controls the ordering shown by `list_available_models` after pi's preferred models are listed first.
+- Preferred models themselves come from pi settings (`defaultProvider`, `defaultModel`, and `enabledModels`).
 
 ### 3. Assign Task & Get Approval
 > **You:** "Create a task for security-bot: 'Check the .env.example file for sensitive defaults' and set it to in_progress."
@@ -204,7 +187,7 @@ You are a scout agent. Investigate the codebase quickly and report findings conc
 name: builder
 description: Implementation specialist
 tools: read,write,edit,bash
-model: claude-sonnet-4
+model: claude-agent-sdk/claude-sonnet-4-6
 thinking: medium
 ---
 You are a builder agent. Implement code following the plan provided. Write clean, tested code.
@@ -214,7 +197,7 @@ You are a builder agent. Implement code following the plan provided. Write clean
 - `name` (required): The agent's name
 - `description` (required): What the agent does
 - `tools` (optional): Comma or space-separated list of allowed tools
-- `model` (optional): Model to use (e.g., `claude-sonnet-4`, `gpt-4o`)
+- `model` (optional): Fully qualified model to use (e.g., `claude-agent-sdk/claude-sonnet-4-6`, `openai-codex/gpt-5.4`)
 - `thinking` (optional): Thinking level (`off`, `minimal`, `low`, `medium`, `high`)
 
 ### Use Predefined Teams
@@ -234,7 +217,7 @@ This single command:
 3. Each agent gets its predefined prompt, tools, model, and thinking settings
 
 **With options:**
-> **You:** "Create a team named 'big-team' from 'full' predefined team using 'gpt-4o' as default model and separate windows."
+> **You:** "Create a team named 'big-team' from 'full' predefined team using 'openai-codex/gpt-5.4' as default model and separate windows."
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,38 @@ When you specify a model name without a provider (e.g., `gemini-2.5-flash`), pi-
 
 > **Example:** Specifying `gemini-2.5-flash` will automatically use `google-gemini-cli/gemini-2.5-flash` if available, saving API costs.
 
+**Configuring provider resolution:**
+You can customize this behavior globally with `~/.pi/pi-teams.json` or per-project with `.pi/pi-teams.json`.
+Project-local config overrides global config.
+
+```json
+{
+  "providerPriority": [
+    "google-gemini-cli",
+    "github-copilot",
+    "kimi-sub",
+    "anthropic",
+    "openai",
+    "google",
+    "zai",
+    "azure-openai",
+    "amazon-bedrock",
+    "mistral",
+    "groq",
+    "cerebras",
+    "xai",
+    "vercel-ai-gateway",
+    "openrouter"
+  ],
+  "explicitOnlyProviders": ["openrouter"]
+}
+```
+
+- `providerPriority`: Controls the order used when multiple providers match a bare model name.
+- `explicitOnlyProviders`: Providers that are ignored for bare model names and only used when you explicitly specify `provider/model`.
+
+> **Example:** With `"explicitOnlyProviders": ["openrouter"]`, `model: "gpt-5"` will not resolve to OpenRouter unless you explicitly use `openrouter/gpt-5`.
+
 ### 3. Assign Task & Get Approval
 > **You:** "Create a task for security-bot: 'Check the .env.example file for sensitive defaults' and set it to in_progress."
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -30,11 +30,11 @@ pi
 
 Create your first team:
 
-> **You:** "Create a team named 'my-team'"
+> **You:** "List available models for team creation, then create a team named 'my-team' using 'openai-codex/gpt-5.4'"
 
 Set a default model for all teammates:
 
-> **You:** "Create a team named 'Research' and use 'gpt-4o' for everyone"
+> **You:** "List available models for team creation, then create a team named 'Research' and use 'openai-codex/gpt-5.4' for everyone"
 
 ---
 
@@ -42,15 +42,16 @@ Set a default model for all teammates:
 
 ### 1. Code Review Team
 
-> **You:** "Create a team named 'code-review' using 'gpt-4o'"
+> **You:** "List available models for team creation"
+> **You:** "Create a team named 'code-review' using 'openai-codex/gpt-5.4'"
 > **You:** "Spawn a teammate named 'security-reviewer' to check for vulnerabilities"
-> **You:** "Spawn a teammate named 'performance-reviewer' using 'haiku' to check for optimization opportunities"
+> **You:** "Spawn a teammate named 'performance-reviewer' using 'claude-agent-sdk/claude-sonnet-4-6' to check for optimization opportunities"
 > **You:** "Create a task for security-reviewer: 'Review the auth module for SQL injection risks' and set it to in_progress"
 > **You:** "Create a task for performance-reviewer: 'Analyze the database queries for N+1 issues' and set it to in_progress"
 
 ### 2. Refactor with Plan Approval
 
-> **You:** "Create a team named 'refactor-squad'"
+> **You:** "Create a team named 'refactor-squad' using 'openai-codex/gpt-5.4'"
 > **You:** "Spawn a teammate named 'refactor-bot' and require plan approval before they make any changes"
 > **You:** "Create a task for refactor-bot: 'Refactor the user service to use dependency injection' and set it to in_progress"
 
@@ -83,7 +84,7 @@ npm run lint
 echo "All checks passed!"
 ```
 
-> **You:** "Create a team named 'test-team'"
+> **You:** "Create a team named 'test-team' using 'openai-codex/gpt-5.4'"
 > **You:** "Spawn a teammate named 'qa-bot' to write tests"
 > **You:** "Create a task for qa-bot: 'Write unit tests for the payment module' and set it to in_progress"
 
@@ -91,9 +92,9 @@ When qa-bot marks the task as completed, the hook automatically runs tests and l
 
 ### 4. Coordinated Migration
 
-> **You:** "Create a team named 'migration-team'"
+> **You:** "Create a team named 'migration-team' using 'openai-codex/gpt-5.4'"
 > **You:** "Spawn a teammate named 'db-migrator' to handle database changes"
-> **You:** "Spawn a teammate named 'api-updater' using 'gpt-4o' to update API endpoints"
+> **You:** "Spawn a teammate named 'api-updater' using 'openai-codex/gpt-5.4' to update API endpoints"
 > **You:** "Spawn a teammate named 'test-writer' to write tests for the migration"
 > **You:** "Create a task for db-migrator: 'Add new columns to the users table' and set it to in_progress"
 
@@ -105,10 +106,11 @@ After db-migrator completes, broadcast the schema change:
 
 Use different models for cost optimization:
 
-> **You:** "Create a team named 'mixed-speed' using 'gpt-4o'"
-> **You:** "Spawn a teammate named 'architect' using 'gpt-4o' with 'xhigh' thinking level for design decisions"
-> **You:** "Spawn a teammate named 'implementer' using 'haiku' with 'low' thinking level for quick coding"
-> **You:** "Spawn a teammate named 'reviewer' using 'gpt-4o' with 'medium' thinking level for code reviews"
+> **You:** "List available models for team creation"
+> **You:** "Create a team named 'mixed-speed' using 'openai-codex/gpt-5.4'"
+> **You:** "Spawn a teammate named 'architect' using 'openai-codex/gpt-5.4' with 'xhigh' thinking level for design decisions"
+> **You:** "Spawn a teammate named 'implementer' using 'claude-agent-sdk/claude-sonnet-4-6' with 'low' thinking level for quick coding"
+> **You:** "Spawn a teammate named 'reviewer' using 'openai-codex/gpt-5.4' with 'medium' thinking level for code reviews"
 
 Now you have expensive reasoning for design and reviews, but fast/cheap implementation.
 
@@ -225,13 +227,13 @@ Balanced teams typically include:
 Example:
 ```bash
 # Design/Review duo (expensive but thorough)
-spawn "architect" using "gpt-4o" with "xhigh" thinking
-spawn "reviewer" using "gpt-4o" with "medium" thinking
+spawn "architect" using "openai-codex/gpt-5.4" with "xhigh" thinking
+spawn "reviewer" using "openai-codex/gpt-5.4" with "medium" thinking
 
 # Implementation trio (fast and cheap)
-spawn "backend-dev" using "haiku" with "low" thinking
-spawn "frontend-dev" using "haiku" with "low" thinking
-spawn "test-writer" using "haiku" with "off" thinking
+spawn "backend-dev" using "claude-agent-sdk/claude-sonnet-4-6" with "low" thinking
+spawn "frontend-dev" using "claude-agent-sdk/claude-sonnet-4-6" with "low" thinking
+spawn "test-writer" using "claude-agent-sdk/claude-sonnet-4-6" with "off" thinking
 ```
 
 ### 3. Plan Approval for High-Risk Changes
@@ -322,15 +324,17 @@ pi  # Then try to use tmux commands
 
 **Problem**: "Model not found" or similar errors.
 
-**Solution**: Check the model name is correct and available in your pi config. Some model names vary between providers:
+**Solution**: Use `list_available_models` first and then pass a fully qualified `provider/model` string.
 
-- `gpt-4o` - OpenAI
-- `haiku` - Anthropic (usually `claude-3-5-haiku`)
-- `glm-4.7` - Zhipu AI
+Examples:
+- `openai-codex/gpt-5.4`
+- `claude-agent-sdk/claude-sonnet-4-6`
+- `kimi-coding/kimi-for-coding`
 
-Check your pi config for available models.
+pi-teams does not auto-resolve bare model names like `gpt-5` or `haiku` when creating new teams or spawning new teammates.
+If a model is not fully qualified or not available, pi-teams fails fast.
 
-If you want to control which provider wins for bare model names, add global or project-local pi-teams config:
+If you want to control the order shown by `list_available_models`, add global or project-local pi-teams config:
 
 - Global: `~/.pi/pi-teams.json`
 - Project-local: `.pi/pi-teams.json`
@@ -340,27 +344,14 @@ Example:
 ```json
 {
   "providerPriority": [
-    "google-gemini-cli",
-    "github-copilot",
-    "kimi-sub",
-    "anthropic",
-    "openai",
-    "google",
-    "zai",
-    "azure-openai",
-    "amazon-bedrock",
-    "mistral",
-    "groq",
-    "cerebras",
-    "xai",
-    "vercel-ai-gateway",
-    "openrouter"
-  ],
-  "explicitOnlyProviders": ["openrouter"]
+    "openai-codex",
+    "claude-agent-sdk",
+    "kimi-coding"
+  ]
 }
 ```
 
-With `explicitOnlyProviders`, a provider is ignored for bare model names like `gpt-5` and only used when you explicitly specify `provider/model`.
+Preferred models are still taken from pi settings (`defaultProvider`, `defaultModel`, and `enabledModels`) and are listed first.
 
 ### Data Location
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -330,6 +330,38 @@ pi  # Then try to use tmux commands
 
 Check your pi config for available models.
 
+If you want to control which provider wins for bare model names, add global or project-local pi-teams config:
+
+- Global: `~/.pi/pi-teams.json`
+- Project-local: `.pi/pi-teams.json`
+
+Example:
+
+```json
+{
+  "providerPriority": [
+    "google-gemini-cli",
+    "github-copilot",
+    "kimi-sub",
+    "anthropic",
+    "openai",
+    "google",
+    "zai",
+    "azure-openai",
+    "amazon-bedrock",
+    "mistral",
+    "groq",
+    "cerebras",
+    "xai",
+    "vercel-ai-gateway",
+    "openrouter"
+  ],
+  "explicitOnlyProviders": ["openrouter"]
+}
+```
+
+With `explicitOnlyProviders`, a provider is ignored for bare model names like `gpt-5` and only used when you explicitly specify `provider/model`.
+
 ### Data Location
 
 All team data is stored in:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,6 +19,22 @@ Complete documentation of all tools, parameters, and automated behavior.
 
 ## Team Management
 
+### list_available_models
+
+List available fully qualified models for creating new teams and spawning new teammates.
+
+Use this tool before choosing a model. pi-teams expects fully qualified `provider/model` strings and rejects bare names like `gpt-5` or `haiku`.
+
+**Returns**:
+- Available models, already sorted with preferred models first
+- Preferred models derived from pi settings
+- Provider priority from pi-teams config (if configured)
+
+**Example**:
+```javascript
+list_available_models({})
+```
+
 ### team_create
 
 Start a new team with optional default model.
@@ -26,12 +42,12 @@ Start a new team with optional default model.
 **Parameters**:
 - `team_name` (required): Name for the team
 - `description` (optional): Team description
-- `default_model` (optional): Default AI model for all teammates (e.g., `gpt-4o`, `haiku`, `glm-4.7`)
+- `default_model` (optional): Fully qualified default AI model for all teammates (for example, `openai-codex/gpt-5.4`)
 
 **Examples**:
 ```javascript
 team_create({ team_name: "my-team" })
-team_create({ team_name: "research", default_model: "gpt-4o" })
+team_create({ team_name: "research", default_model: "openai-codex/gpt-5.4" })
 ```
 
 ---
@@ -81,13 +97,15 @@ Launch a new agent into a terminal pane with a role and instructions.
 - `name` (required): Friendly name for the teammate (e.g., "security-bot")
 - `prompt` (required): Instructions for the teammate's role and initial task
 - `cwd` (required): Working directory for the teammate
-- `model` (optional): AI model for this teammate (overrides team default)
+- `model` (optional): Fully qualified AI model for this teammate (overrides team default)
 - `thinking` (optional): Thinking level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`)
 - `plan_mode_required` (optional): If `true`, teammate must submit plans for approval
 
-**Model Options**:
-- Any model available in your pi configuration
-- Common models: `gpt-4o`, `haiku` (Anthropic), `glm-4.7`, `glm-5` (Zhipu AI)
+**Model Rules**:
+- Use `list_available_models` first when choosing a model for a new team or teammate
+- Models must be fully qualified `provider/model` strings
+- If `model` is omitted, the team must already have a fully qualified default model
+- Unknown or unqualified models fail fast
 
 **Thinking Levels**:
 - `off`: No thinking blocks (fastest)
@@ -113,7 +131,7 @@ spawn_teammate({
   name: "speed-bot",
   prompt: "Run benchmarks on the API endpoints",
   cwd: "/path/to/project",
-  model: "haiku"
+  model: "claude-agent-sdk/claude-sonnet-4-6"
 })
 
 // With plan approval
@@ -131,7 +149,7 @@ spawn_teammate({
   name: "architect-bot",
   prompt: "Design the new feature architecture",
   cwd: "/path/to/project",
-  model: "gpt-4o",
+  model: "openai-codex/gpt-5.4",
   thinking: "xhigh"
 })
 ```
@@ -520,17 +538,17 @@ All pi-teams data is stored in your home directory under `~/.pi/`:
 {
   "name": "my-team",
   "description": "Code review team",
-  "defaultModel": "gpt-4o",
+  "defaultModel": "openai-codex/gpt-5.4",
   "members": [
     {
       "name": "security-bot",
-      "model": "gpt-4o",
+      "model": "openai-codex/gpt-5.4",
       "thinking": "medium",
       "planModeRequired": true
     },
     {
       "name": "frontend-dev",
-      "model": "haiku",
+      "model": "claude-agent-sdk/claude-sonnet-4-6",
       "thinking": "low",
       "planModeRequired": false
     }
@@ -575,9 +593,9 @@ All pi-teams data is stored in your home directory under `~/.pi/`:
 }
 ```
 
-### Model Resolution Configuration
+### Model Listing Configuration
 
-You can customize how pi-teams resolves bare model names like `gpt-5` or `haiku`.
+You can customize how `list_available_models` orders providers after preferred models are listed first.
 
 Supported config locations:
 - Global: `~/.pi/pi-teams.json`
@@ -590,29 +608,15 @@ Example:
 ```json
 {
   "providerPriority": [
-    "google-gemini-cli",
-    "github-copilot",
-    "kimi-sub",
-    "anthropic",
-    "openai",
-    "google",
-    "zai",
-    "azure-openai",
-    "amazon-bedrock",
-    "mistral",
-    "groq",
-    "cerebras",
-    "xai",
-    "vercel-ai-gateway",
-    "openrouter"
-  ],
-  "explicitOnlyProviders": ["openrouter"]
+    "openai-codex",
+    "claude-agent-sdk",
+    "kimi-coding"
+  ]
 }
 ```
 
 Fields:
-- `providerPriority`: Ordered list used when more than one provider matches the same bare model name.
-- `explicitOnlyProviders`: Providers that are skipped for bare model names and only used when you explicitly provide `provider/model`.
+- `providerPriority`: Ordered list used to sort the output from `list_available_models` after preferred models are listed first.
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -575,6 +575,45 @@ All pi-teams data is stored in your home directory under `~/.pi/`:
 }
 ```
 
+### Model Resolution Configuration
+
+You can customize how pi-teams resolves bare model names like `gpt-5` or `haiku`.
+
+Supported config locations:
+- Global: `~/.pi/pi-teams.json`
+- Project-local: `.pi/pi-teams.json`
+
+Project-local config overrides global config.
+
+Example:
+
+```json
+{
+  "providerPriority": [
+    "google-gemini-cli",
+    "github-copilot",
+    "kimi-sub",
+    "anthropic",
+    "openai",
+    "google",
+    "zai",
+    "azure-openai",
+    "amazon-bedrock",
+    "mistral",
+    "groq",
+    "cerebras",
+    "xai",
+    "vercel-ai-gateway",
+    "openrouter"
+  ],
+  "explicitOnlyProviders": ["openrouter"]
+}
+```
+
+Fields:
+- `providerPriority`: Ordered list used when more than one provider matches the same bare model name.
+- `explicitOnlyProviders`: Providers that are skipped for bare model names and only used when you explicitly provide `provider/model`.
+
 ---
 
 ## Environment Variables

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -10,6 +10,10 @@ import { Member } from "../src/utils/models";
 import { getTerminalAdapter } from "../src/adapters/terminal-registry";
 import { Iterm2Adapter } from "../src/adapters/iterm2-adapter";
 import * as predefined from "../src/utils/predefined-teams";
+import {
+  loadModelResolutionConfig,
+  resolveModelWithProvider,
+} from "../src/utils/model-resolution";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -101,83 +105,10 @@ function getAvailableModels(): Array<{ provider: string; model: string }> {
   }
 }
 
-/**
- * Provider priority list - OAuth/subscription providers first (cheaper), then API-key providers
- */
-const PROVIDER_PRIORITY = [
-  // OAuth / Subscription providers (typically free/cheaper)
-  "google-gemini-cli",  // Google Gemini CLI - OAuth, free tier
-  "github-copilot",     // GitHub Copilot - subscription
-  "kimi-sub",           // Kimi subscription
-  // API key providers
-  "anthropic",
-  "openai",
-  "google",
-  "zai",
-  "openrouter",
-  "azure-openai",
-  "amazon-bedrock",
-  "mistral",
-  "groq",
-  "cerebras",
-  "xai",
-  "vercel-ai-gateway",
-];
-
-/**
- * Find the best matching provider for a given model name.
- * Returns the full provider/model string or null if not found.
- */
-function resolveModelWithProvider(modelName: string): string | null {
-  // If already has provider prefix, return as-is
-  if (modelName.includes("/")) {
-    return modelName;
-  }
-
+function resolveConfiguredModel(modelName: string): string | null {
   const availableModels = getAvailableModels();
-  if (availableModels.length === 0) {
-    return null;
-  }
-
-  const lowerModelName = modelName.toLowerCase();
-
-  // Find all exact matches (case-insensitive) and sort by provider priority
-  const exactMatches = availableModels.filter(
-    (m) => m.model.toLowerCase() === lowerModelName
-  );
-
-  if (exactMatches.length > 0) {
-    // Sort by provider priority (lower index = higher priority)
-    exactMatches.sort((a, b) => {
-      const aIndex = PROVIDER_PRIORITY.indexOf(a.provider);
-      const bIndex = PROVIDER_PRIORITY.indexOf(b.provider);
-      // If provider not in priority list, put it at the end
-      const aPriority = aIndex === -1 ? 999 : aIndex;
-      const bPriority = bIndex === -1 ? 999 : bIndex;
-      return aPriority - bPriority;
-    });
-    return `${exactMatches[0].provider}/${exactMatches[0].model}`;
-  }
-
-  // Try partial match (model name contains the search term)
-  const partialMatches = availableModels.filter((m) =>
-    m.model.toLowerCase().includes(lowerModelName)
-  );
-
-  if (partialMatches.length > 0) {
-    for (const preferredProvider of PROVIDER_PRIORITY) {
-      const match = partialMatches.find(
-        (m) => m.provider === preferredProvider
-      );
-      if (match) {
-        return `${match.provider}/${match.model}`;
-      }
-    }
-    // Return first match if no preferred provider found
-    return `${partialMatches[0].provider}/${partialMatches[0].model}`;
-  }
-
-  return null;
+  const config = loadModelResolutionConfig({ projectDir: process.cwd() });
+  return resolveModelWithProvider(modelName, availableModels, config);
 }
 
 /**
@@ -585,8 +516,8 @@ export default function (pi: ExtensionAPI) {
       // Resolve model to provider/model format
       if (chosenModel) {
         if (!chosenModel.includes('/')) {
-          // Try to resolve using available models from pi --list-models
-          const resolved = resolveModelWithProvider(chosenModel);
+          // Try to resolve using available models plus local/global pi-teams config
+          const resolved = resolveConfiguredModel(chosenModel);
           if (resolved) {
             chosenModel = resolved;
           } else if (teamConfig.defaultModel && teamConfig.defaultModel.includes('/')) {
@@ -1144,7 +1075,7 @@ export default function (pi: ExtensionAPI) {
           let chosenModel = agentDef.model || params.default_model || config.defaultModel;
           
           if (chosenModel && !chosenModel.includes('/')) {
-            const resolved = resolveModelWithProvider(chosenModel);
+            const resolved = resolveConfiguredModel(chosenModel);
             if (resolved) {
               chosenModel = resolved;
             } else if (config.defaultModel && config.defaultModel.includes('/')) {

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -11,8 +11,12 @@ import { getTerminalAdapter } from "../src/adapters/terminal-registry";
 import { Iterm2Adapter } from "../src/adapters/iterm2-adapter";
 import * as predefined from "../src/utils/predefined-teams";
 import {
+  isKnownQualifiedModel,
+  listPreferredQualifiedModels,
   loadModelResolutionConfig,
-  resolveModelWithProvider,
+  loadPiModelSettings,
+  normalizeQualifiedModel,
+  sortAvailableModels,
 } from "../src/utils/model-resolution";
 import * as path from "node:path";
 import * as fs from "node:fs";
@@ -105,10 +109,53 @@ function getAvailableModels(): Array<{ provider: string; model: string }> {
   }
 }
 
-function resolveConfiguredModel(modelName: string): string | null {
+function getModelSelectionState(projectDir: string, preferredModels: string[] = []) {
   const availableModels = getAvailableModels();
-  const config = loadModelResolutionConfig({ projectDir: process.cwd() });
-  return resolveModelWithProvider(modelName, availableModels, config);
+  const piSettings = loadPiModelSettings({ projectDir });
+  const config = loadModelResolutionConfig({ projectDir });
+  const preferredQualifiedModels = listPreferredQualifiedModels(availableModels, {
+    projectDir,
+    preferredModels,
+  });
+  const sortedModels = sortAvailableModels(availableModels, {
+    preferredModels: preferredQualifiedModels,
+    providerPriority: config.providerPriority,
+  });
+
+  return {
+    availableModels,
+    piSettings,
+    providerPriority: config.providerPriority,
+    preferredQualifiedModels,
+    sortedModels,
+  };
+}
+
+function requireQualifiedKnownModel(
+  model: string | undefined,
+  availableModels: Array<{ provider: string; model: string }>,
+  fieldName: string
+): string | undefined {
+  if (!model) {
+    return undefined;
+  }
+
+  const normalized = normalizeQualifiedModel(model);
+  if (!normalized) {
+    throw new Error(
+      `${fieldName} must be a fully qualified provider/model string. ` +
+      `Use list_available_models to choose a valid model.`
+    );
+  }
+
+  if (!isKnownQualifiedModel(normalized, availableModels)) {
+    throw new Error(
+      `${fieldName} \"${normalized}\" is not available. ` +
+      `Use list_available_models to choose a valid model.`
+    );
+  }
+
+  return normalized;
 }
 
 /**
@@ -446,23 +493,85 @@ export default function (pi: ExtensionAPI) {
 
   // Tools
   pi.registerTool({
+    name: "list_available_models",
+    label: "List Available Models",
+    description: "List available fully qualified models for team creation and teammate spawning. Use this before creating a new team or spawning teammates. Models must be specified as provider/model.",
+    parameters: Type.Object({}),
+    async execute(toolCallId, params: any, signal, onUpdate, ctx) {
+      const state = getModelSelectionState(ctx.cwd);
+      const lines = [
+        "Choose a fully qualified provider/model string from this list when creating teams or spawning teammates.",
+        "Unqualified model names like \"gpt-5\" or \"haiku\" are not accepted.",
+      ];
+
+      if (state.preferredQualifiedModels.length > 0) {
+        lines.push("", "Preferred models (from pi settings, in priority order):");
+        for (const model of state.preferredQualifiedModels) {
+          lines.push(`- ${model}`);
+        }
+      }
+
+      if (state.providerPriority.length > 0) {
+        lines.push("", "Provider priority (from pi-teams config):");
+        for (const provider of state.providerPriority) {
+          lines.push(`- ${provider}`);
+        }
+      }
+
+      if (state.piSettings.defaultModel || state.piSettings.enabledModels?.length) {
+        lines.push("", "Pi model settings:");
+        if (state.piSettings.defaultProvider) {
+          lines.push(`- defaultProvider: ${state.piSettings.defaultProvider}`);
+        }
+        if (state.piSettings.defaultModel) {
+          lines.push(`- defaultModel: ${state.piSettings.defaultModel}`);
+        }
+        if (state.piSettings.enabledModels?.length) {
+          lines.push(`- enabledModels: ${state.piSettings.enabledModels.join(", ")}`);
+        }
+      }
+
+      lines.push("", "Available models (already sorted with preferred models first):");
+      for (const model of state.sortedModels) {
+        const tags: string[] = [];
+        if (model.preferred) tags.push("preferred");
+        if (model.providerPriorityIndex !== Number.MAX_SAFE_INTEGER) tags.push(`provider-priority:${model.providerPriorityIndex + 1}`);
+        lines.push(`- ${model.qualified}${tags.length ? ` [${tags.join(", ")}]` : ""}`);
+      }
+
+      return {
+        content: [{ type: "text", text: lines.join("\n") }],
+        details: {
+          preferredModels: state.preferredQualifiedModels,
+          providerPriority: state.providerPriority,
+          piSettings: state.piSettings,
+          models: state.sortedModels,
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
     name: "team_create",
     label: "Create Team",
-    description: "Create a new agent team.",
+    description: "Create a new agent team. If you specify default_model, it must be a fully qualified provider/model string from list_available_models.",
     parameters: Type.Object({
       team_name: Type.String(),
       description: Type.Optional(Type.String()),
-      default_model: Type.Optional(Type.String()),
+      default_model: Type.Optional(Type.String({ description: "Fully qualified default model (provider/model). Use list_available_models first." })),
       separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
+      const { availableModels } = getModelSelectionState(ctx.cwd);
+      const defaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
+
       // Auto-cleanup stale team if the previous lead process is dead
       // This handles the case where a session was aborted and restarted
       if (teams.teamExists(params.team_name)) {
         cleanupStaleTeam(params.team_name, terminal);
       }
       
-      const config = teams.createTeam(params.team_name, "local-session", "lead-agent", params.description, params.default_model, params.separate_windows);
+      const config = teams.createTeam(params.team_name, "local-session", "lead-agent", params.description, defaultModel, params.separate_windows);
       // Register this session as the lead so it can receive inbox messages
       registerLeadSession(params.team_name);
       // Update teamName and start inbox polling for the lead
@@ -478,13 +587,13 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "spawn_teammate",
     label: "Spawn Teammate",
-    description: "Spawn a new teammate in a terminal pane or separate window.",
+    description: "Spawn a new teammate in a terminal pane or separate window. The model must be a fully qualified provider/model string from list_available_models, or the team must already have a fully qualified default model.",
     parameters: Type.Object({
       team_name: Type.String(),
       name: Type.String(),
       prompt: Type.String(),
       cwd: Type.String(),
-      model: Type.Optional(Type.String()),
+      model: Type.Optional(Type.String({ description: "Fully qualified model (provider/model). Use list_available_models first." })),
       thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"])),
       plan_mode_required: Type.Optional(Type.Boolean({ default: false })),
       separate_window: Type.Optional(Type.Boolean({ default: false })),
@@ -511,21 +620,15 @@ export default function (pi: ExtensionAPI) {
         await teams.removeMember(safeTeamName, safeName);
       }
       
-      let chosenModel = params.model || teamConfig.defaultModel;
+      const { availableModels } = getModelSelectionState(ctx.cwd, [teamConfig.defaultModel].filter(Boolean) as string[]);
+      const explicitModel = requireQualifiedKnownModel(params.model, availableModels, "model");
+      const teamDefaultModel = requireQualifiedKnownModel(teamConfig.defaultModel, availableModels, "team default model");
+      const chosenModel = explicitModel || teamDefaultModel;
 
-      // Resolve model to provider/model format
-      if (chosenModel) {
-        if (!chosenModel.includes('/')) {
-          // Try to resolve using available models plus local/global pi-teams config
-          const resolved = resolveConfiguredModel(chosenModel);
-          if (resolved) {
-            chosenModel = resolved;
-          } else if (teamConfig.defaultModel && teamConfig.defaultModel.includes('/')) {
-            // Fall back to team default provider
-            const [provider] = teamConfig.defaultModel.split('/');
-            chosenModel = `${provider}/${chosenModel}`;
-          }
-        }
+      if (!chosenModel) {
+        throw new Error(
+          "No model specified. Use list_available_models to choose a fully qualified provider/model and pass it as model, or create the team with a fully qualified default_model."
+        );
       }
 
       const useSeparateWindow = params.separate_window ?? teamConfig.separateWindows ?? false;
@@ -1028,12 +1131,12 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "create_predefined_team",
     label: "Create Predefined Team",
-    description: "Create a team from a predefined team configuration. Spawns all agents defined in the team template from teams.yaml. Each agent is spawned with its predefined prompt, tools, and settings.",
+    description: "Create a team from a predefined team configuration. Any default_model you pass must be a fully qualified provider/model string from list_available_models. Agent definitions with models must also already be fully qualified.",
     parameters: Type.Object({
       team_name: Type.String({ description: "Name for the new team instance" }),
       predefined_team: Type.String({ description: "Name of the predefined team template from teams.yaml" }),
       cwd: Type.String({ description: "Working directory for spawned agents" }),
-      default_model: Type.Optional(Type.String({ description: "Default model for agents without a specified model" })),
+      default_model: Type.Optional(Type.String({ description: "Fully qualified default model (provider/model) for agents without a specified model. Use list_available_models first." })),
       separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
@@ -1049,8 +1152,11 @@ export default function (pi: ExtensionAPI) {
         throw new Error("No terminal adapter detected.");
       }
 
+      const { availableModels } = getModelSelectionState(ctx.cwd);
+      const defaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
+
       // Create the team
-      const config = teams.createTeam(params.team_name, "local-session", "lead-agent", `Predefined team: ${params.predefined_team}`, params.default_model, params.separate_windows);
+      const config = teams.createTeam(params.team_name, "local-session", "lead-agent", `Predefined team: ${params.predefined_team}`, defaultModel, params.separate_windows);
       registerLeadSession(params.team_name);
       // Update teamName and start inbox polling for the lead
       teamName = params.team_name;
@@ -1072,16 +1178,13 @@ export default function (pi: ExtensionAPI) {
           const safeName = paths.sanitizeName(agentName);
           const safeTeamName = paths.sanitizeName(params.team_name);
           
-          let chosenModel = agentDef.model || params.default_model || config.defaultModel;
-          
-          if (chosenModel && !chosenModel.includes('/')) {
-            const resolved = resolveConfiguredModel(chosenModel);
-            if (resolved) {
-              chosenModel = resolved;
-            } else if (config.defaultModel && config.defaultModel.includes('/')) {
-              const [provider] = config.defaultModel.split('/');
-              chosenModel = `${provider}/${chosenModel}`;
-            }
+          const agentModel = requireQualifiedKnownModel(agentDef.model, availableModels, `model for predefined agent \"${agentName}\"`);
+          const chosenModel = agentModel || defaultModel || config.defaultModel;
+
+          if (!chosenModel) {
+            throw new Error(
+              `No model specified for predefined agent \"${agentName}\". Add a fully qualified model to the agent definition or pass a fully qualified default_model.`
+            );
           }
 
           const useSeparateWindow = params.separate_windows ?? config.separateWindows ?? false;

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -92,6 +92,13 @@ async function getModelSelectionState(ctx: any, projectDir: string, preferredMod
   };
 }
 
+function getCurrentQualifiedModel(ctx: any): string | undefined {
+  if (!ctx.model?.provider || !ctx.model?.id) {
+    return undefined;
+  }
+  return `${ctx.model.provider}/${ctx.model.id}`;
+}
+
 function requireQualifiedKnownModel(
   model: string | undefined,
   availableModels: Array<{ provider: string; model: string }>,
@@ -515,16 +522,18 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "team_create",
     label: "Create Team",
-    description: "Create a new agent team. If you specify default_model, it must be a fully qualified provider/model string from list_available_models.",
+    description: "Create a new agent team. If you specify default_model, it must be a fully qualified provider/model string from list_available_models. If omitted, the current active model is used.",
     parameters: Type.Object({
       team_name: Type.String(),
       description: Type.Optional(Type.String()),
-      default_model: Type.Optional(Type.String({ description: "Fully qualified default model (provider/model). Use list_available_models first." })),
+      default_model: Type.Optional(Type.String({ description: "Fully qualified default model (provider/model). Use list_available_models first. If omitted, the current active model is used." })),
       separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
       const { availableModels } = await getModelSelectionState(ctx, ctx.cwd);
-      const defaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
+      const explicitDefaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
+      const currentModel = requireQualifiedKnownModel(getCurrentQualifiedModel(ctx), availableModels, "current model");
+      const defaultModel = explicitDefaultModel || currentModel;
 
       // Auto-cleanup stale team if the previous lead process is dead
       // This handles the case where a session was aborted and restarted
@@ -548,13 +557,13 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "spawn_teammate",
     label: "Spawn Teammate",
-    description: "Spawn a new teammate in a terminal pane or separate window. The model must be a fully qualified provider/model string from list_available_models, or the team must already have a fully qualified default model.",
+    description: "Spawn a new teammate in a terminal pane or separate window. The model must be a fully qualified provider/model string from list_available_models. If omitted, pi-teams uses the team's default model, or else the current active model.",
     parameters: Type.Object({
       team_name: Type.String(),
       name: Type.String(),
       prompt: Type.String(),
       cwd: Type.String(),
-      model: Type.Optional(Type.String({ description: "Fully qualified model (provider/model). Use list_available_models first." })),
+      model: Type.Optional(Type.String({ description: "Fully qualified model (provider/model). Use list_available_models first. If omitted, pi-teams uses the team's default model, or else the current active model." })),
       thinking: Type.Optional(StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"])),
       plan_mode_required: Type.Optional(Type.Boolean({ default: false })),
       separate_window: Type.Optional(Type.Boolean({ default: false })),
@@ -581,14 +590,16 @@ export default function (pi: ExtensionAPI) {
         await teams.removeMember(safeTeamName, safeName);
       }
       
-      const { availableModels } = await getModelSelectionState(ctx, ctx.cwd, [teamConfig.defaultModel].filter(Boolean) as string[]);
+      const currentModelHint = getCurrentQualifiedModel(ctx);
+      const { availableModels } = await getModelSelectionState(ctx, ctx.cwd, [teamConfig.defaultModel, currentModelHint].filter(Boolean) as string[]);
       const explicitModel = requireQualifiedKnownModel(params.model, availableModels, "model");
       const teamDefaultModel = requireQualifiedKnownModel(teamConfig.defaultModel, availableModels, "team default model");
-      const chosenModel = explicitModel || teamDefaultModel;
+      const currentModel = requireQualifiedKnownModel(currentModelHint, availableModels, "current model");
+      const chosenModel = explicitModel || teamDefaultModel || currentModel;
 
       if (!chosenModel) {
         throw new Error(
-          "No model specified. Use list_available_models to choose a fully qualified provider/model and pass it as model, or create the team with a fully qualified default_model."
+          "No model specified. Use list_available_models to choose a fully qualified provider/model and pass it as model, create the team with a fully qualified default_model, or ensure the current session has an active model."
         );
       }
 
@@ -1092,12 +1103,12 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "create_predefined_team",
     label: "Create Predefined Team",
-    description: "Create a team from a predefined team configuration. Any default_model you pass must be a fully qualified provider/model string from list_available_models. Agent definitions with models must also already be fully qualified.",
+    description: "Create a team from a predefined team configuration. Any default_model you pass must be a fully qualified provider/model string from list_available_models. If omitted, the current active model is used. Agent definitions with models must also already be fully qualified.",
     parameters: Type.Object({
       team_name: Type.String({ description: "Name for the new team instance" }),
       predefined_team: Type.String({ description: "Name of the predefined team template from teams.yaml" }),
       cwd: Type.String({ description: "Working directory for spawned agents" }),
-      default_model: Type.Optional(Type.String({ description: "Fully qualified default model (provider/model) for agents without a specified model. Use list_available_models first." })),
+      default_model: Type.Optional(Type.String({ description: "Fully qualified default model (provider/model) for agents without a specified model. Use list_available_models first. If omitted, the current active model is used." })),
       separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
@@ -1114,7 +1125,9 @@ export default function (pi: ExtensionAPI) {
       }
 
       const { availableModels } = await getModelSelectionState(ctx, ctx.cwd);
-      const defaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
+      const explicitDefaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
+      const currentModel = requireQualifiedKnownModel(getCurrentQualifiedModel(ctx), availableModels, "current model");
+      const defaultModel = explicitDefaultModel || currentModel;
 
       // Create the team
       const config = teams.createTeam(params.team_name, "local-session", "lead-agent", `Predefined team: ${params.predefined_team}`, defaultModel, params.separate_windows);

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -21,7 +21,6 @@ import {
 import * as path from "node:path";
 import * as fs from "node:fs";
 import * as os from "node:os";
-import { spawnSync } from "node:child_process";
 
 /**
  * Build the command used to relaunch pi for teammate processes.
@@ -59,58 +58,20 @@ function getPiLaunchCommand(): string {
   return "pi";
 }
 
-// Cache for available models
-let availableModelsCache: Array<{ provider: string; model: string }> | null = null;
-let modelsCacheTime = 0;
-const MODELS_CACHE_TTL = 60000; // 1 minute
-
-/**
- * Query available models from pi --list-models
- */
-function getAvailableModels(): Array<{ provider: string; model: string }> {
-  const now = Date.now();
-  if (availableModelsCache && now - modelsCacheTime < MODELS_CACHE_TTL) {
-    return availableModelsCache;
-  }
-
+async function getAvailableModels(ctx: any): Promise<Array<{ provider: string; model: string }>> {
   try {
-    const result = spawnSync("pi", ["--list-models"], {
-      encoding: "utf-8",
-      timeout: 10000,
-    });
-
-    if (result.status !== 0 || !result.stdout) {
-      return [];
-    }
-
-    const models: Array<{ provider: string; model: string }> = [];
-    const lines = result.stdout.split("\n");
-
-    for (const line of lines) {
-      // Skip header line and empty lines
-      if (!line.trim() || line.startsWith("provider")) continue;
-
-      // Parse: provider model context max-out thinking images
-      const parts = line.trim().split(/\s+/);
-      if (parts.length >= 2) {
-        const provider = parts[0];
-        const model = parts[1];
-        if (provider && model) {
-          models.push({ provider, model });
-        }
-      }
-    }
-
-    availableModelsCache = models;
-    modelsCacheTime = now;
-    return models;
-  } catch (e) {
+    const available = await ctx.modelRegistry.getAvailable();
+    return available.map((model: any) => ({
+      provider: model.provider,
+      model: model.id,
+    }));
+  } catch {
     return [];
   }
 }
 
-function getModelSelectionState(projectDir: string, preferredModels: string[] = []) {
-  const availableModels = getAvailableModels();
+async function getModelSelectionState(ctx: any, projectDir: string, preferredModels: string[] = []) {
+  const availableModels = await getAvailableModels(ctx);
   const piSettings = loadPiModelSettings({ projectDir });
   const config = loadModelResolutionConfig({ projectDir });
   const preferredQualifiedModels = listPreferredQualifiedModels(availableModels, {
@@ -498,7 +459,7 @@ export default function (pi: ExtensionAPI) {
     description: "List available fully qualified models for team creation and teammate spawning. Use this before creating a new team or spawning teammates. Models must be specified as provider/model.",
     parameters: Type.Object({}),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
-      const state = getModelSelectionState(ctx.cwd);
+      const state = await getModelSelectionState(ctx, ctx.cwd);
       const lines = [
         "Choose a fully qualified provider/model string from this list when creating teams or spawning teammates.",
         "Unqualified model names like \"gpt-5\" or \"haiku\" are not accepted.",
@@ -562,7 +523,7 @@ export default function (pi: ExtensionAPI) {
       separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
-      const { availableModels } = getModelSelectionState(ctx.cwd);
+      const { availableModels } = await getModelSelectionState(ctx, ctx.cwd);
       const defaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
 
       // Auto-cleanup stale team if the previous lead process is dead
@@ -620,7 +581,7 @@ export default function (pi: ExtensionAPI) {
         await teams.removeMember(safeTeamName, safeName);
       }
       
-      const { availableModels } = getModelSelectionState(ctx.cwd, [teamConfig.defaultModel].filter(Boolean) as string[]);
+      const { availableModels } = await getModelSelectionState(ctx, ctx.cwd, [teamConfig.defaultModel].filter(Boolean) as string[]);
       const explicitModel = requireQualifiedKnownModel(params.model, availableModels, "model");
       const teamDefaultModel = requireQualifiedKnownModel(teamConfig.defaultModel, availableModels, "team default model");
       const chosenModel = explicitModel || teamDefaultModel;
@@ -1152,7 +1113,7 @@ export default function (pi: ExtensionAPI) {
         throw new Error("No terminal adapter detected.");
       }
 
-      const { availableModels } = getModelSelectionState(ctx.cwd);
+      const { availableModels } = await getModelSelectionState(ctx, ctx.cwd);
       const defaultModel = requireQualifiedKnownModel(params.default_model, availableModels, "default_model");
 
       // Create the team

--- a/src/utils/model-resolution.test.ts
+++ b/src/utils/model-resolution.test.ts
@@ -3,57 +3,52 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  DEFAULT_PROVIDER_PRIORITY,
+  buildPreferredModelsFromSettings,
+  isKnownQualifiedModel,
+  isQualifiedModel,
+  listPreferredQualifiedModels,
   loadModelResolutionConfig,
-  resolveModelWithProvider,
+  loadPiModelSettings,
+  normalizeQualifiedModel,
+  parseQualifiedModel,
+  sortAvailableModels,
+  stripThinkingSuffix,
   type AvailableModel,
 } from "./model-resolution";
 
 const availableModels: AvailableModel[] = [
   { provider: "openrouter", model: "gpt-5" },
   { provider: "openai-codex", model: "gpt-5.4" },
-  { provider: "anthropic", model: "claude-sonnet-4" },
-  { provider: "github-copilot", model: "claude-sonnet-4" },
+  { provider: "claude-agent-sdk", model: "claude-sonnet-4-6" },
+  { provider: "claude-agent-sdk", model: "claude-opus-4-7" },
+  { provider: "kimi-coding", model: "kimi-for-coding" },
 ];
 
-describe("resolveModelWithProvider", () => {
-  it("returns provider-qualified models as-is", () => {
-    expect(resolveModelWithProvider("openrouter/gpt-5", availableModels)).toBe("openrouter/gpt-5");
-  });
-
-  it("uses configured provider priority for exact matches", () => {
-    const resolved = resolveModelWithProvider("claude-sonnet-4", availableModels, {
-      providerPriority: ["anthropic", "github-copilot"],
+describe("qualified model helpers", () => {
+  it("parses qualified models", () => {
+    expect(parseQualifiedModel("openai-codex/gpt-5.4")).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.4",
     });
-
-    expect(resolved).toBe("anthropic/claude-sonnet-4");
   });
 
-  it("supports explicit-only providers for bare model names", () => {
-    const resolved = resolveModelWithProvider("gpt-5", availableModels, {
-      explicitOnlyProviders: ["openrouter"],
-    });
-
-    expect(resolved).toBe("openai-codex/gpt-5.4");
+  it("strips thinking suffixes", () => {
+    expect(stripThinkingSuffix("openai-codex/gpt-5.4:high")).toBe("openai-codex/gpt-5.4");
   });
 
-  it("returns null when only explicit-only providers match", () => {
-    const resolved = resolveModelWithProvider(
-      "gpt-5",
-      [{ provider: "openrouter", model: "gpt-5" }],
-      { explicitOnlyProviders: ["openrouter"] }
-    );
-
-    expect(resolved).toBeNull();
+  it("detects qualified models", () => {
+    expect(isQualifiedModel("openai-codex/gpt-5.4")).toBe(true);
+    expect(isQualifiedModel("gpt-5")).toBe(false);
   });
 
-  it("falls back to default provider priority when no config is supplied", () => {
-    const resolved = resolveModelWithProvider("claude-sonnet-4", availableModels);
-    const highestPriority = DEFAULT_PROVIDER_PRIORITY.find((provider) =>
-      ["anthropic", "github-copilot"].includes(provider)
-    );
+  it("normalizes qualified models", () => {
+    expect(normalizeQualifiedModel("openai-codex/gpt-5.4:high")).toBe("openai-codex/gpt-5.4");
+    expect(normalizeQualifiedModel("gpt-5")).toBeNull();
+  });
 
-    expect(resolved).toBe(`${highestPriority}/claude-sonnet-4`);
+  it("checks known qualified models", () => {
+    expect(isKnownQualifiedModel("openai-codex/gpt-5.4", availableModels)).toBe(true);
+    expect(isKnownQualifiedModel("openrouter/gpt-4o", availableModels)).toBe(false);
   });
 });
 
@@ -72,46 +67,149 @@ describe("loadModelResolutionConfig", () => {
     fs.rmSync(testRoot, { recursive: true, force: true });
   });
 
-  it("loads defaults when no config files exist", () => {
+  it("loads empty defaults when no config files exist", () => {
     fs.rmSync(path.join(homeDir, ".pi"), { recursive: true, force: true });
     fs.rmSync(path.join(projectDir, ".pi"), { recursive: true, force: true });
 
     const config = loadModelResolutionConfig({ homeDir, projectDir });
 
-    expect(config.providerPriority).toEqual(DEFAULT_PROVIDER_PRIORITY);
-    expect(config.explicitOnlyProviders).toEqual([]);
+    expect(config.providerPriority).toEqual([]);
   });
 
   it("loads global config", () => {
     fs.writeFileSync(
       path.join(homeDir, ".pi", "pi-teams.json"),
-      JSON.stringify({ explicitOnlyProviders: ["openrouter"] }, null, 2)
+      JSON.stringify({ providerPriority: ["openai-codex", "claude-agent-sdk"] }, null, 2)
     );
 
     const config = loadModelResolutionConfig({ homeDir, projectDir });
 
-    expect(config.explicitOnlyProviders).toEqual(["openrouter"]);
+    expect(config.providerPriority).toEqual(["openai-codex", "claude-agent-sdk"]);
   });
 
   it("lets project config override global config", () => {
     fs.writeFileSync(
       path.join(homeDir, ".pi", "pi-teams.json"),
-      JSON.stringify({
-        providerPriority: ["github-copilot", "anthropic"],
-        explicitOnlyProviders: ["openrouter"],
-      }, null, 2)
+      JSON.stringify({ providerPriority: ["claude-agent-sdk"] }, null, 2)
     );
     fs.writeFileSync(
       path.join(projectDir, ".pi", "pi-teams.json"),
-      JSON.stringify({
-        providerPriority: ["anthropic", "github-copilot"],
-        explicitOnlyProviders: [],
-      }, null, 2)
+      JSON.stringify({ providerPriority: ["openai-codex"] }, null, 2)
     );
 
     const config = loadModelResolutionConfig({ homeDir, projectDir });
 
-    expect(config.providerPriority).toEqual(["anthropic", "github-copilot"]);
-    expect(config.explicitOnlyProviders).toEqual([]);
+    expect(config.providerPriority).toEqual(["openai-codex"]);
+  });
+});
+
+describe("loadPiModelSettings", () => {
+  const testRoot = path.join(os.tmpdir(), `pi-teams-pi-settings-${Date.now()}`);
+  const homeDir = path.join(testRoot, "home");
+  const projectDir = path.join(testRoot, "project");
+
+  beforeEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+    fs.mkdirSync(path.join(homeDir, ".pi", "agent"), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, ".pi"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it("loads global pi settings", () => {
+    fs.writeFileSync(
+      path.join(homeDir, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        defaultProvider: "openai-codex",
+        defaultModel: "gpt-5.4",
+        enabledModels: ["claude-*"],
+      }, null, 2)
+    );
+
+    const settings = loadPiModelSettings({ homeDir, projectDir });
+
+    expect(settings.defaultProvider).toBe("openai-codex");
+    expect(settings.defaultModel).toBe("gpt-5.4");
+    expect(settings.enabledModels).toEqual(["claude-*"]);
+  });
+
+  it("lets project pi settings override global settings", () => {
+    fs.writeFileSync(
+      path.join(homeDir, ".pi", "agent", "settings.json"),
+      JSON.stringify({ defaultProvider: "claude-agent-sdk", defaultModel: "claude-opus-4-7" }, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(projectDir, ".pi", "settings.json"),
+      JSON.stringify({ defaultProvider: "openai-codex", defaultModel: "gpt-5.4" }, null, 2)
+    );
+
+    const settings = loadPiModelSettings({ homeDir, projectDir });
+
+    expect(settings.defaultProvider).toBe("openai-codex");
+    expect(settings.defaultModel).toBe("gpt-5.4");
+  });
+});
+
+describe("preferred model selection", () => {
+  it("builds preferred models from explicit preferences and pi settings", () => {
+    const preferred = buildPreferredModelsFromSettings(
+      availableModels,
+      {
+        defaultProvider: "openai-codex",
+        defaultModel: "gpt-5.4",
+        enabledModels: ["claude-*", "kimi-for-coding"],
+      },
+      ["claude-agent-sdk/claude-opus-4-7"]
+    );
+
+    expect(preferred).toEqual([
+      "claude-agent-sdk/claude-opus-4-7",
+      "openai-codex/gpt-5.4",
+      "claude-agent-sdk/claude-sonnet-4-6",
+      "kimi-coding/kimi-for-coding",
+    ]);
+  });
+
+  it("lists preferred qualified models from on-disk settings", () => {
+    const testRoot = path.join(os.tmpdir(), `pi-teams-preferred-${Date.now()}`);
+    const homeDir = path.join(testRoot, "home");
+
+    fs.mkdirSync(path.join(homeDir, ".pi", "agent"), { recursive: true });
+    fs.writeFileSync(
+      path.join(homeDir, ".pi", "agent", "settings.json"),
+      JSON.stringify({
+        defaultProvider: "openai-codex",
+        defaultModel: "gpt-5.4",
+        enabledModels: ["claude-*"],
+      }, null, 2)
+    );
+
+    const preferred = listPreferredQualifiedModels(availableModels, { homeDir });
+    expect(preferred).toEqual([
+      "openai-codex/gpt-5.4",
+      "claude-agent-sdk/claude-sonnet-4-6",
+      "claude-agent-sdk/claude-opus-4-7",
+    ]);
+
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+});
+
+describe("sortAvailableModels", () => {
+  it("sorts preferred models first, then provider priority, then alphabetically", () => {
+    const sorted = sortAvailableModels(availableModels, {
+      preferredModels: ["openai-codex/gpt-5.4", "claude-agent-sdk/claude-sonnet-4-6"],
+      providerPriority: ["kimi-coding", "claude-agent-sdk"],
+    });
+
+    expect(sorted.map((model) => model.qualified)).toEqual([
+      "openai-codex/gpt-5.4",
+      "claude-agent-sdk/claude-sonnet-4-6",
+      "kimi-coding/kimi-for-coding",
+      "claude-agent-sdk/claude-opus-4-7",
+      "openrouter/gpt-5",
+    ]);
   });
 });

--- a/src/utils/model-resolution.test.ts
+++ b/src/utils/model-resolution.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_PROVIDER_PRIORITY,
+  loadModelResolutionConfig,
+  resolveModelWithProvider,
+  type AvailableModel,
+} from "./model-resolution";
+
+const availableModels: AvailableModel[] = [
+  { provider: "openrouter", model: "gpt-5" },
+  { provider: "openai-codex", model: "gpt-5.4" },
+  { provider: "anthropic", model: "claude-sonnet-4" },
+  { provider: "github-copilot", model: "claude-sonnet-4" },
+];
+
+describe("resolveModelWithProvider", () => {
+  it("returns provider-qualified models as-is", () => {
+    expect(resolveModelWithProvider("openrouter/gpt-5", availableModels)).toBe("openrouter/gpt-5");
+  });
+
+  it("uses configured provider priority for exact matches", () => {
+    const resolved = resolveModelWithProvider("claude-sonnet-4", availableModels, {
+      providerPriority: ["anthropic", "github-copilot"],
+    });
+
+    expect(resolved).toBe("anthropic/claude-sonnet-4");
+  });
+
+  it("supports explicit-only providers for bare model names", () => {
+    const resolved = resolveModelWithProvider("gpt-5", availableModels, {
+      explicitOnlyProviders: ["openrouter"],
+    });
+
+    expect(resolved).toBe("openai-codex/gpt-5.4");
+  });
+
+  it("returns null when only explicit-only providers match", () => {
+    const resolved = resolveModelWithProvider(
+      "gpt-5",
+      [{ provider: "openrouter", model: "gpt-5" }],
+      { explicitOnlyProviders: ["openrouter"] }
+    );
+
+    expect(resolved).toBeNull();
+  });
+
+  it("falls back to default provider priority when no config is supplied", () => {
+    const resolved = resolveModelWithProvider("claude-sonnet-4", availableModels);
+    const highestPriority = DEFAULT_PROVIDER_PRIORITY.find((provider) =>
+      ["anthropic", "github-copilot"].includes(provider)
+    );
+
+    expect(resolved).toBe(`${highestPriority}/claude-sonnet-4`);
+  });
+});
+
+describe("loadModelResolutionConfig", () => {
+  const testRoot = path.join(os.tmpdir(), `pi-teams-model-config-${Date.now()}`);
+  const homeDir = path.join(testRoot, "home");
+  const projectDir = path.join(testRoot, "project");
+
+  beforeEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+    fs.mkdirSync(path.join(homeDir, ".pi"), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, ".pi"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it("loads defaults when no config files exist", () => {
+    fs.rmSync(path.join(homeDir, ".pi"), { recursive: true, force: true });
+    fs.rmSync(path.join(projectDir, ".pi"), { recursive: true, force: true });
+
+    const config = loadModelResolutionConfig({ homeDir, projectDir });
+
+    expect(config.providerPriority).toEqual(DEFAULT_PROVIDER_PRIORITY);
+    expect(config.explicitOnlyProviders).toEqual([]);
+  });
+
+  it("loads global config", () => {
+    fs.writeFileSync(
+      path.join(homeDir, ".pi", "pi-teams.json"),
+      JSON.stringify({ explicitOnlyProviders: ["openrouter"] }, null, 2)
+    );
+
+    const config = loadModelResolutionConfig({ homeDir, projectDir });
+
+    expect(config.explicitOnlyProviders).toEqual(["openrouter"]);
+  });
+
+  it("lets project config override global config", () => {
+    fs.writeFileSync(
+      path.join(homeDir, ".pi", "pi-teams.json"),
+      JSON.stringify({
+        providerPriority: ["github-copilot", "anthropic"],
+        explicitOnlyProviders: ["openrouter"],
+      }, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(projectDir, ".pi", "pi-teams.json"),
+      JSON.stringify({
+        providerPriority: ["anthropic", "github-copilot"],
+        explicitOnlyProviders: [],
+      }, null, 2)
+    );
+
+    const config = loadModelResolutionConfig({ homeDir, projectDir });
+
+    expect(config.providerPriority).toEqual(["anthropic", "github-copilot"]);
+    expect(config.explicitOnlyProviders).toEqual([]);
+  });
+});

--- a/src/utils/model-resolution.ts
+++ b/src/utils/model-resolution.ts
@@ -9,66 +9,60 @@ export interface AvailableModel {
 
 export interface ModelResolutionConfig {
   providerPriority?: string[];
-  explicitOnlyProviders?: string[];
 }
 
 export interface ResolvedModelResolutionConfig {
   providerPriority: string[];
-  explicitOnlyProviders: string[];
 }
 
-/**
- * Default provider priority used for bare model names.
- * OAuth/subscription providers go first, then API-key providers.
- */
-export const DEFAULT_PROVIDER_PRIORITY = [
-  "google-gemini-cli",
-  "github-copilot",
-  "kimi-sub",
-  "anthropic",
-  "openai",
-  "google",
-  "zai",
-  "openrouter",
-  "azure-openai",
-  "amazon-bedrock",
-  "mistral",
-  "groq",
-  "cerebras",
-  "xai",
-  "vercel-ai-gateway",
-];
+export interface PiModelSettings {
+  defaultProvider?: string;
+  defaultModel?: string;
+  enabledModels?: string[];
+}
+
+export interface SortedModel extends AvailableModel {
+  qualified: string;
+  preferred: boolean;
+  preferredIndex: number;
+  providerPriorityIndex: number;
+}
+
+const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh"]);
 
 function normalizeList(values: unknown): string[] | undefined {
-  if (!Array.isArray(values)) {
-    return undefined;
-  }
+  if (!Array.isArray(values)) return undefined;
 
   const normalized = values
-    .map((value) => String(value).trim().toLowerCase())
+    .map((value) => String(value).trim())
     .filter(Boolean);
 
   return normalized.length > 0 ? Array.from(new Set(normalized)) : [];
 }
 
-function readConfigFile(configPath: string): ModelResolutionConfig {
-  if (!fs.existsSync(configPath)) {
-    return {};
-  }
+function readJsonFile<T>(filePath: string): T | null {
+  if (!fs.existsSync(filePath)) return null;
 
   try {
-    const parsed = JSON.parse(fs.readFileSync(configPath, "utf-8")) as ModelResolutionConfig;
-    return {
-      providerPriority: normalizeList(parsed.providerPriority),
-      explicitOnlyProviders: normalizeList(parsed.explicitOnlyProviders),
-    };
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
   } catch {
-    return {};
+    return null;
   }
 }
 
+function readConfigFile(configPath: string): ModelResolutionConfig {
+  const parsed = readJsonFile<ModelResolutionConfig>(configPath);
+  if (!parsed) {
+    return {};
+  }
+
+  return {
+    providerPriority: normalizeList(parsed.providerPriority)?.map((value) => value.toLowerCase()),
+  };
+}
+
 /**
- * Loads model resolution config.
+ * Loads pi-teams model-selection preferences.
  *
  * Supported locations:
  * - ~/.pi/pi-teams.json
@@ -87,88 +81,237 @@ export function loadModelResolutionConfig(options?: {
   const projectConfigPath = projectDir ? path.join(projectDir, ".pi", "pi-teams.json") : null;
 
   const merged: ResolvedModelResolutionConfig = {
-    providerPriority: [...DEFAULT_PROVIDER_PRIORITY],
-    explicitOnlyProviders: [],
+    providerPriority: [],
   };
 
   for (const configPath of [globalConfigPath, projectConfigPath]) {
     if (!configPath) continue;
 
     const config = readConfigFile(configPath);
-    if (config.providerPriority && config.providerPriority.length > 0) {
+    if (config.providerPriority) {
       merged.providerPriority = config.providerPriority;
-    }
-    if (config.explicitOnlyProviders) {
-      merged.explicitOnlyProviders = config.explicitOnlyProviders;
     }
   }
 
   return merged;
 }
 
-function sortByProviderPriority(
-  models: AvailableModel[],
-  providerPriority: string[]
-): AvailableModel[] {
-  return [...models].sort((a, b) => {
-    const aIndex = providerPriority.indexOf(a.provider.toLowerCase());
-    const bIndex = providerPriority.indexOf(b.provider.toLowerCase());
-    const aPriority = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;
-    const bPriority = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex;
-    return aPriority - bPriority;
-  });
+/**
+ * Loads pi settings relevant to model selection.
+ *
+ * Supported locations:
+ * - ~/.pi/agent/settings.json
+ * - <project>/.pi/settings.json
+ *
+ * Project-local settings override global settings.
+ */
+export function loadPiModelSettings(options?: {
+  projectDir?: string;
+  homeDir?: string;
+}): PiModelSettings {
+  const homeDir = options?.homeDir ?? os.homedir();
+  const projectDir = options?.projectDir;
+
+  const globalSettingsPath = path.join(homeDir, ".pi", "agent", "settings.json");
+  const projectSettingsPath = projectDir ? path.join(projectDir, ".pi", "settings.json") : null;
+
+  const merged: PiModelSettings = {};
+
+  for (const settingsPath of [globalSettingsPath, projectSettingsPath]) {
+    if (!settingsPath) continue;
+
+    const settings = readJsonFile<PiModelSettings>(settingsPath);
+    if (!settings) continue;
+
+    if (typeof settings.defaultProvider === "string" && settings.defaultProvider.trim()) {
+      merged.defaultProvider = settings.defaultProvider.trim();
+    }
+    if (typeof settings.defaultModel === "string" && settings.defaultModel.trim()) {
+      merged.defaultModel = settings.defaultModel.trim();
+    }
+    if (Array.isArray(settings.enabledModels)) {
+      merged.enabledModels = settings.enabledModels
+        .map((value) => String(value).trim())
+        .filter(Boolean);
+    }
+  }
+
+  return merged;
 }
 
-/**
- * Finds the best matching provider/model string for an unqualified model name.
- * Providers listed in explicitOnlyProviders are ignored unless the caller passes
- * a fully qualified provider/model string.
- */
-export function resolveModelWithProvider(
-  modelName: string,
-  availableModels: AvailableModel[],
-  config?: Partial<ResolvedModelResolutionConfig>
-): string | null {
-  if (modelName.includes("/")) {
-    return modelName;
+export function stripThinkingSuffix(specifier: string): string {
+  const trimmed = specifier.trim();
+  const lastColon = trimmed.lastIndexOf(":");
+  if (lastColon === -1) {
+    return trimmed;
   }
 
-  if (availableModels.length === 0) {
+  const suffix = trimmed.slice(lastColon + 1).toLowerCase();
+  return THINKING_LEVELS.has(suffix) ? trimmed.slice(0, lastColon) : trimmed;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function matchesPattern(pattern: string, value: string): boolean {
+  const normalizedPattern = pattern.toLowerCase();
+  const normalizedValue = value.toLowerCase();
+
+  if (normalizedPattern.includes("*")) {
+    const regex = new RegExp(`^${normalizedPattern.split("*").map(escapeRegex).join(".*")}$`, "i");
+    return regex.test(value);
+  }
+
+  return normalizedValue === normalizedPattern || normalizedValue.includes(normalizedPattern);
+}
+
+export function parseQualifiedModel(specifier: string): AvailableModel | null {
+  const cleaned = stripThinkingSuffix(specifier);
+  const slashIndex = cleaned.indexOf("/");
+  if (slashIndex === -1) {
     return null;
   }
 
-  const providerPriority = config?.providerPriority?.length
-    ? config.providerPriority.map((value) => value.toLowerCase())
-    : DEFAULT_PROVIDER_PRIORITY;
-  const explicitOnlyProviders = new Set(
-    (config?.explicitOnlyProviders ?? []).map((value) => value.toLowerCase())
-  );
-
-  const candidates = availableModels.filter(
-    (model) => !explicitOnlyProviders.has(model.provider.toLowerCase())
-  );
-
-  if (candidates.length === 0) {
+  const provider = cleaned.slice(0, slashIndex).trim();
+  const model = cleaned.slice(slashIndex + 1).trim();
+  if (!provider || !model) {
     return null;
   }
 
-  const lowerModelName = modelName.toLowerCase();
+  return { provider, model };
+}
 
-  const exactMatches = candidates.filter(
-    (model) => model.model.toLowerCase() === lowerModelName
-  );
-  if (exactMatches.length > 0) {
-    const preferred = sortByProviderPriority(exactMatches, providerPriority)[0];
-    return `${preferred.provider}/${preferred.model}`;
+export function isQualifiedModel(specifier: string): boolean {
+  return parseQualifiedModel(specifier) !== null;
+}
+
+export function normalizeQualifiedModel(specifier: string): string | null {
+  const parsed = parseQualifiedModel(specifier);
+  return parsed ? `${parsed.provider}/${parsed.model}` : null;
+}
+
+function qualifyDefaultModel(settings: PiModelSettings): string | null {
+  if (!settings.defaultModel) {
+    return null;
   }
 
-  const partialMatches = candidates.filter((model) =>
-    model.model.toLowerCase().includes(lowerModelName)
-  );
-  if (partialMatches.length > 0) {
-    const preferred = sortByProviderPriority(partialMatches, providerPriority)[0];
-    return `${preferred.provider}/${preferred.model}`;
+  if (isQualifiedModel(settings.defaultModel)) {
+    return normalizeQualifiedModel(settings.defaultModel);
+  }
+
+  if (settings.defaultProvider) {
+    return `${settings.defaultProvider}/${stripThinkingSuffix(settings.defaultModel)}`;
   }
 
   return null;
+}
+
+/**
+ * Builds a list of preferred fully-qualified models from pi settings.
+ *
+ * Order is significant:
+ * 1. preferredModels passed by the caller (must already be fully qualified)
+ * 2. pi default model (qualified via defaultProvider when necessary)
+ * 3. available models matching enabledModels patterns, in settings order
+ */
+export function buildPreferredModelsFromSettings(
+  availableModels: AvailableModel[],
+  settings: PiModelSettings,
+  preferredModels: string[] = []
+): string[] {
+  const results: string[] = [];
+  const seen = new Set<string>();
+
+  const push = (specifier?: string | null) => {
+    if (!specifier) return;
+    const normalized = normalizeQualifiedModel(specifier);
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    results.push(normalized);
+  };
+
+  for (const model of preferredModels) {
+    push(model);
+  }
+
+  push(qualifyDefaultModel(settings));
+
+  for (const pattern of settings.enabledModels ?? []) {
+    const cleanedPattern = stripThinkingSuffix(pattern);
+    for (const availableModel of availableModels) {
+      const qualified = `${availableModel.provider}/${availableModel.model}`;
+      const target = cleanedPattern.includes("/") ? qualified : availableModel.model;
+      if (matchesPattern(cleanedPattern, target)) {
+        push(qualified);
+      }
+    }
+  }
+
+  return results;
+}
+
+export function listPreferredQualifiedModels(
+  availableModels: AvailableModel[],
+  options?: {
+    projectDir?: string;
+    homeDir?: string;
+    preferredModels?: string[];
+  }
+): string[] {
+  const settings = loadPiModelSettings(options);
+  return buildPreferredModelsFromSettings(availableModels, settings, options?.preferredModels ?? []);
+}
+
+export function sortAvailableModels(
+  availableModels: AvailableModel[],
+  options?: {
+    preferredModels?: string[];
+    providerPriority?: string[];
+  }
+): SortedModel[] {
+  const preferredModels = options?.preferredModels ?? [];
+  const providerPriority = (options?.providerPriority ?? []).map((value) => value.toLowerCase());
+
+  const preferredIndex = new Map(preferredModels.map((value, index) => [value, index]));
+  const providerPriorityIndex = new Map(providerPriority.map((value, index) => [value, index]));
+
+  return availableModels
+    .map((model) => {
+      const qualified = `${model.provider}/${model.model}`;
+      return {
+        ...model,
+        qualified,
+        preferred: preferredIndex.has(qualified),
+        preferredIndex: preferredIndex.get(qualified) ?? Number.MAX_SAFE_INTEGER,
+        providerPriorityIndex: providerPriorityIndex.get(model.provider.toLowerCase()) ?? Number.MAX_SAFE_INTEGER,
+      };
+    })
+    .sort((a, b) => {
+      if (a.preferred !== b.preferred) {
+        return a.preferred ? -1 : 1;
+      }
+      if (a.preferredIndex !== b.preferredIndex) {
+        return a.preferredIndex - b.preferredIndex;
+      }
+      if (a.providerPriorityIndex !== b.providerPriorityIndex) {
+        return a.providerPriorityIndex - b.providerPriorityIndex;
+      }
+      const providerCompare = a.provider.localeCompare(b.provider);
+      if (providerCompare !== 0) {
+        return providerCompare;
+      }
+      return a.model.localeCompare(b.model);
+    });
+}
+
+export function isKnownQualifiedModel(model: string, availableModels: AvailableModel[]): boolean {
+  const normalized = normalizeQualifiedModel(model);
+  if (!normalized) {
+    return false;
+  }
+
+  return availableModels.some(
+    (availableModel) => `${availableModel.provider}/${availableModel.model}` === normalized
+  );
 }

--- a/src/utils/model-resolution.ts
+++ b/src/utils/model-resolution.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface AvailableModel {
+  provider: string;
+  model: string;
+}
+
+export interface ModelResolutionConfig {
+  providerPriority?: string[];
+  explicitOnlyProviders?: string[];
+}
+
+export interface ResolvedModelResolutionConfig {
+  providerPriority: string[];
+  explicitOnlyProviders: string[];
+}
+
+/**
+ * Default provider priority used for bare model names.
+ * OAuth/subscription providers go first, then API-key providers.
+ */
+export const DEFAULT_PROVIDER_PRIORITY = [
+  "google-gemini-cli",
+  "github-copilot",
+  "kimi-sub",
+  "anthropic",
+  "openai",
+  "google",
+  "zai",
+  "openrouter",
+  "azure-openai",
+  "amazon-bedrock",
+  "mistral",
+  "groq",
+  "cerebras",
+  "xai",
+  "vercel-ai-gateway",
+];
+
+function normalizeList(values: unknown): string[] | undefined {
+  if (!Array.isArray(values)) {
+    return undefined;
+  }
+
+  const normalized = values
+    .map((value) => String(value).trim().toLowerCase())
+    .filter(Boolean);
+
+  return normalized.length > 0 ? Array.from(new Set(normalized)) : [];
+}
+
+function readConfigFile(configPath: string): ModelResolutionConfig {
+  if (!fs.existsSync(configPath)) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf-8")) as ModelResolutionConfig;
+    return {
+      providerPriority: normalizeList(parsed.providerPriority),
+      explicitOnlyProviders: normalizeList(parsed.explicitOnlyProviders),
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Loads model resolution config.
+ *
+ * Supported locations:
+ * - ~/.pi/pi-teams.json
+ * - <project>/.pi/pi-teams.json
+ *
+ * Project-local config overrides global config.
+ */
+export function loadModelResolutionConfig(options?: {
+  projectDir?: string;
+  homeDir?: string;
+}): ResolvedModelResolutionConfig {
+  const homeDir = options?.homeDir ?? os.homedir();
+  const projectDir = options?.projectDir;
+
+  const globalConfigPath = path.join(homeDir, ".pi", "pi-teams.json");
+  const projectConfigPath = projectDir ? path.join(projectDir, ".pi", "pi-teams.json") : null;
+
+  const merged: ResolvedModelResolutionConfig = {
+    providerPriority: [...DEFAULT_PROVIDER_PRIORITY],
+    explicitOnlyProviders: [],
+  };
+
+  for (const configPath of [globalConfigPath, projectConfigPath]) {
+    if (!configPath) continue;
+
+    const config = readConfigFile(configPath);
+    if (config.providerPriority && config.providerPriority.length > 0) {
+      merged.providerPriority = config.providerPriority;
+    }
+    if (config.explicitOnlyProviders) {
+      merged.explicitOnlyProviders = config.explicitOnlyProviders;
+    }
+  }
+
+  return merged;
+}
+
+function sortByProviderPriority(
+  models: AvailableModel[],
+  providerPriority: string[]
+): AvailableModel[] {
+  return [...models].sort((a, b) => {
+    const aIndex = providerPriority.indexOf(a.provider.toLowerCase());
+    const bIndex = providerPriority.indexOf(b.provider.toLowerCase());
+    const aPriority = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;
+    const bPriority = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex;
+    return aPriority - bPriority;
+  });
+}
+
+/**
+ * Finds the best matching provider/model string for an unqualified model name.
+ * Providers listed in explicitOnlyProviders are ignored unless the caller passes
+ * a fully qualified provider/model string.
+ */
+export function resolveModelWithProvider(
+  modelName: string,
+  availableModels: AvailableModel[],
+  config?: Partial<ResolvedModelResolutionConfig>
+): string | null {
+  if (modelName.includes("/")) {
+    return modelName;
+  }
+
+  if (availableModels.length === 0) {
+    return null;
+  }
+
+  const providerPriority = config?.providerPriority?.length
+    ? config.providerPriority.map((value) => value.toLowerCase())
+    : DEFAULT_PROVIDER_PRIORITY;
+  const explicitOnlyProviders = new Set(
+    (config?.explicitOnlyProviders ?? []).map((value) => value.toLowerCase())
+  );
+
+  const candidates = availableModels.filter(
+    (model) => !explicitOnlyProviders.has(model.provider.toLowerCase())
+  );
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const lowerModelName = modelName.toLowerCase();
+
+  const exactMatches = candidates.filter(
+    (model) => model.model.toLowerCase() === lowerModelName
+  );
+  if (exactMatches.length > 0) {
+    const preferred = sortByProviderPriority(exactMatches, providerPriority)[0];
+    return `${preferred.provider}/${preferred.model}`;
+  }
+
+  const partialMatches = candidates.filter((model) =>
+    model.model.toLowerCase().includes(lowerModelName)
+  );
+  if (partialMatches.length > 0) {
+    const preferred = sortByProviderPriority(partialMatches, providerPriority)[0];
+    return `${preferred.provider}/${preferred.model}`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
This PR replaces smart model resolution in `pi-teams` with a stricter, more explicit model-selection workflow.

The main changes are:
- add `list_available_models` so the orchestrator can see real, currently available models from the pi runtime
- require fully qualified `provider/model` values when a model is explicitly provided for new teams or new teammates
- fail fast for unknown or unqualified explicit model names instead of trying to guess what the user meant
- use pi settings only to influence ordering/preferences in model selection output, not to silently rewrite explicit model choices
- use `ctx.modelRegistry.getAvailable()` in-process instead of shelling out to `pi --list-models`
- if a model is omitted, fall back to the current active model (or team default model when present)

## Why
I ran into problems immediately while trying to use `pi-teams` in a normal workflow.

In particular, ambiguous model names like `gpt-5` could end up resolving to providers the user did not intend, including providers that may cost money or fail due to missing auth. That made the old smart-resolution behavior feel too magical for a workflow that directly affects cost, reliability, and user expectations.

This change tries to make the workflow better across the board by making model choice:
- explicit when explicitly requested
- inspectable
- validated against what is actually available in the running pi session
- consistent with the user’s currently active model when no explicit override is given

## Final behavior
For newly created teams / newly spawned teammates:
- users (or the orchestrator model) can call `list_available_models`
- then choose a fully qualified `provider/model`
- unqualified names like `gpt-5` or `haiku` are rejected when explicitly provided
- unknown fully qualified models are rejected

If no explicit model is provided:
- `team_create` uses the current active model
- `spawn_teammate` uses the team default model, or else the current active model
- `create_predefined_team` uses the current active model when no explicit `default_model` is provided

For pre-existing team configurations:
- nothing new needs to be inferred
- if the config already has explicit models baked in, that continues to work as-is

## Important note
I want to be explicit that this PR includes a fairly opinionated workflow change, and I made a number of product/design decisions here without prior discussion.

Please treat this as a contribution you can adopt, adapt, partially use, or decline entirely.
If this direction does not fit the project, that is completely fine — in that case I will simply maintain the behavior I need in my own fork.

## Notes on implementation
- available models now come from `ctx.modelRegistry.getAvailable()`
- user preferences still come from pi settings (`defaultProvider`, `defaultModel`, `enabledModels`) and optional `pi-teams` config ordering
- the listing tool already sorts results with preferred models first
- the omission/default behavior now lines up well with the intent behind PR #20, while still keeping explicit model selection strict and validated

## Validation
- `npm test`
- manually verified in pi that:
  - bare explicit models are rejected
  - `list_available_models` returns real runtime models
  - explicit fully qualified models work
  - omitted models fall back to the current active model

## Changelog
- intentionally left untouched
