### PR TITLE
fix: apply agent tool restrictions from .md frontmatter

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -634,6 +634,13 @@ export default function (pi: ExtensionAPI) {
         piCmd = `${piBinary} --thinking ${params.thinking}`;
       }
 
+      // Apply tool restrictions from agent definition (.md frontmatter)
+      const agents = predefined.getAllAgentDefinitions(ctx.cwd);
+      const agentDef = agents.find(a => a.name === safeName);
+      if (agentDef?.tools && agentDef.tools.length > 0) {
+        piCmd = `${piCmd} --tools ${agentDef.tools.join(",")}`;
+      }
+
       const env: Record<string, string> = {
         ...process.env,
         PI_TEAM_NAME: safeTeamName,
@@ -1186,6 +1193,10 @@ export default function (pi: ExtensionAPI) {
             }
           } else if (agentDef.thinking) {
             piCmd = `${piBinary} --thinking ${agentDef.thinking}`;
+          }
+
+          if (agentDef.tools && agentDef.tools.length > 0) {
+            piCmd = `${piCmd} --tools ${agentDef.tools.join(",")}`;
           }
 
           const env: Record<string, string> = {


### PR DESCRIPTION
## Problem

Agent definitions have a `tools` field parsed from .md frontmatter that was never applied when spawning teammates. Every teammate got ALL tools instead of the restricted set defined in their agent file.

## Fix

Added `--tools` flag to the pi launch command in two locations:

- **spawn_teammate** (\~line 638): Look up the agent definition via `predefined.getAllAgentDefinitions(ctx.cwd)`, then append `--tools` if the agent has a tools array defined.

- **create_predefined_team** (\~line 1198): Use the already-available `agentDef` variable to append `--tools` when tools are defined.

Both locations now respect the `tools` field from .md frontmatter, so teammates get their restricted tool set instead of all tools.

## Testing

All 129 existing tests pass.