### PR TITLE
Add Herdr terminal adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-teams 🚀
 
-**pi-teams** turns your single Pi agent into a coordinated software engineering team. It allows you to spawn multiple "Teammate" agents in separate terminal panes that work autonomously, communicate with each other, and manage a shared task board—all mediated through tmux, Zellij, iTerm2, WezTerm, or Windows Terminal.
+**pi-teams** turns your single Pi agent into a coordinated software engineering team. It allows you to spawn multiple "Teammate" agents in separate terminal panes that work autonomously, communicate with each other, and manage a shared task board—all mediated through Herdr, tmux, Zellij, iTerm2, WezTerm, or Windows Terminal.
 
 ### 🖥️ pi-teams in Action
 
@@ -8,7 +8,7 @@
 | :---: | :---: | :---: |
 | <a href="iTerm2.png"><img src="iTerm2.png" width="300" alt="pi-teams in iTerm2"></a> | <a href="tmux.png"><img src="tmux.png" width="300" alt="pi-teams in tmux"></a> | <a href="zellij.png"><img src="zellij.png" width="300" alt="pi-teams in Zellij"></a> |
 
-*Also works with **WezTerm** and **Windows Terminal** (cross-platform support)*
+*Also works with **Herdr**, **WezTerm**, and **Windows Terminal** (cross-platform support)*
 
 ## 🛠 Installation
 
@@ -21,7 +21,7 @@ pi install npm:pi-teams
 ## 🚀 Quick Start
 
 ```bash
-# 1. Start a team (inside tmux, Zellij, or iTerm2)
+# 1. Start a team (inside Herdr, tmux, Zellij, or iTerm2)
 "Create a team named 'my-team' using 'gpt-4o'"
 
 # 2. Spawn teammates
@@ -47,8 +47,8 @@ pi install npm:pi-teams
 ### Advanced Features
 - **Predefined Teams**: Define team templates in `teams.yaml` and spawn entire teams with a single command.
 - **Save Teams as Templates**: Convert any runtime team into a reusable template with a single command.
-- **Isolated OS Windows**: Launch teammates in true separate OS windows instead of panes.
-- **Persistent Window Titles**: Windows are automatically titled `[team-name]: [agent-name]` for easy identification in your window manager.
+- **Isolated Surfaces**: Launch teammates in separate Herdr tabs or true OS windows instead of panes.
+- **Persistent Titles**: Separate surfaces are automatically titled `[team-name]: [agent-name]` for easy identification.
 - **Plan Approval Mode**: Require teammates to submit their implementation plans for your approval before they touch any code.
 - **Broadcast Messaging**: Send a message to the entire team at once for global coordination and announcements.
 - **Quality Gate Hooks**: Automated shell scripts run when tasks are completed (e.g., to run tests or linting).
@@ -62,19 +62,19 @@ pi install npm:pi-teams
 **Set a default model for the whole team:**
 > **You:** "Create a team named 'Research' and use 'gpt-4o' for everyone."
 
-**Start a team in "Separate Windows" mode:**
+**Start a team in separate window/tab mode:**
 > **You:** "Create a team named 'Dev' and open everyone in separate windows."
-*(Supported in iTerm2 and WezTerm only)*
+*(Supported in Herdr as new tabs, and in iTerm2/WezTerm/Windows Terminal as separate OS windows)*
 
 ### 2. Spawn Teammate with Custom Settings
 > **You:** "Spawn a teammate named 'security-bot' in the current folder. Tell them to scan for hardcoded API keys."
 
-**Spawn a specific teammate in a separate window:**
+**Spawn a specific teammate in a separate window/tab surface:**
 > **You:** "Spawn 'researcher' in a separate window."
 
-**Move the Team Lead to a separate window:**
+**Move the Team Lead to a separate window/tab surface:**
 > **You:** "Open the team lead in its own window."
-*(Requires separate_windows mode enabled or iTerm2/WezTerm)*
+*(Requires Herdr, iTerm2, WezTerm, or Windows Terminal)*
 
 **Use a different model:**
 > **You:** "Spawn a teammate named 'speed-bot' using 'haiku' to quickly run some benchmarks."
@@ -258,9 +258,13 @@ Once saved, use it just like any predefined team:
 
 ## 🪟 Terminal Requirements
 
-To show multiple agents on one screen, **pi-teams** requires a way to manage terminal panes. It supports **tmux**, **Zellij**, **iTerm2**, **WezTerm**, and **Windows Terminal**.
+To show multiple agents on one screen, **pi-teams** requires a way to manage terminal panes. It supports **Herdr**, **tmux**, **Zellij**, **iTerm2**, **WezTerm**, and **Windows Terminal**.
 
-### Option 1: tmux (Recommended)
+### Option 1: Herdr
+
+Simply start `pi` inside a Herdr pane. **pi-teams** will detect the `HERDR_ENV`, `HERDR_PANE_ID`, and `HERDR_SOCKET_PATH` environment variables and use `herdr agent start` to spawn teammates in Herdr-managed panes. Separate-window mode maps to new Herdr tabs.
+
+### Option 2: tmux (Recommended)
 
 Install tmux:
 - **macOS**: `brew install tmux`
@@ -272,11 +276,11 @@ tmux  # Start tmux session
 pi   # Start pi inside tmux
 ```
 
-### Option 2: Zellij
+### Option 3: Zellij
 
 Simply start `pi` inside a Zellij session. **pi-teams** will detect it via the `ZELLIJ` environment variable and use `zellij run` to spawn teammates in new panes.
 
-### Option 3: iTerm2 (macOS)
+### Option 4: iTerm2 (macOS)
 
 If you are using **iTerm2** on macOS and are *not* inside tmux or Zellij, **pi-teams** can manage your team in two ways:
 1. **Panes (Default)**: Automatically split your current window into an optimized layout.
@@ -284,7 +288,7 @@ If you are using **iTerm2** on macOS and are *not* inside tmux or Zellij, **pi-t
 
 It will name the panes or windows with the teammate's agent name for easy identification.
 
-### Option 4: WezTerm (macOS, Linux, Windows)
+### Option 5: WezTerm (macOS, Linux, Windows)
 
 **WezTerm** is a GPU-accelerated, cross-platform terminal emulator written in Rust. Like iTerm2, it supports both **Panes** and **Separate OS Windows**.
 
@@ -299,7 +303,7 @@ wezterm  # Start WezTerm
 pi       # Start pi inside WezTerm
 ```
 
-### Option 5: Windows Terminal (Windows)
+### Option 6: Windows Terminal (Windows)
 
 **Windows Terminal** is the modern, feature-rich terminal emulator for Windows 10/11. It supports both **Panes** and **Separate OS Windows**.
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -522,7 +522,7 @@ export default function (pi: ExtensionAPI) {
       team_name: Type.String(),
       description: Type.Optional(Type.String()),
       default_model: Type.Optional(Type.String()),
-      separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
+      separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate window/tab surfaces instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
       // Auto-cleanup stale team if the previous lead process is dead
@@ -547,7 +547,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "spawn_teammate",
     label: "Spawn Teammate",
-    description: "Spawn a new teammate in a terminal pane or separate window.",
+    description: "Spawn a new teammate in a terminal pane or separate window/tab surface.",
     parameters: Type.Object({
       team_name: Type.String(),
       name: Type.String(),
@@ -599,7 +599,7 @@ export default function (pi: ExtensionAPI) {
 
       const useSeparateWindow = params.separate_window ?? teamConfig.separateWindows ?? false;
       if (useSeparateWindow && !terminal.supportsWindows()) {
-        throw new Error(`Separate windows mode is not supported in ${terminal.name}.`);
+        throw new Error(`Separate window/tab surface mode is not supported in ${terminal.name}.`);
       }
 
       const member: Member = {
@@ -680,11 +680,11 @@ export default function (pi: ExtensionAPI) {
           await teams.updateMember(safeTeamName, safeName, { tmuxPaneId: terminalId });
         }
       } catch (e) {
-        throw new Error(`Failed to spawn ${terminal.name} ${isWindow ? 'window' : 'pane'}: ${e}`);
+        throw new Error(`Failed to spawn ${terminal.name} ${isWindow ? 'separate surface' : 'pane'}: ${e}`);
       }
 
       return {
-        content: [{ type: "text", text: `Teammate ${params.name} spawned in ${isWindow ? 'window' : 'pane'} ${terminalId}.` }],
+        content: [{ type: "text", text: `Teammate ${params.name} spawned in ${isWindow ? 'separate surface' : 'pane'} ${terminalId}.` }],
         details: { agentId: member.agentId, terminalId, isWindow },
       };
     },
@@ -693,7 +693,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "spawn_lead_window",
     label: "Spawn Lead Window",
-    description: "Open the team lead in a separate OS window.",
+    description: "Open the team lead in a separate window/tab surface.",
     parameters: Type.Object({
       team_name: Type.String(),
       cwd: Type.Optional(Type.String()),
@@ -701,7 +701,7 @@ export default function (pi: ExtensionAPI) {
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
       const safeTeamName = paths.sanitizeName(params.team_name);
       if (!teams.teamExists(safeTeamName)) throw new Error(`Team ${params.team_name} does not exist`);
-      if (!terminal || !terminal.supportsWindows()) throw new Error("Windows mode not supported.");
+      if (!terminal || !terminal.supportsWindows()) throw new Error("Separate window/tab surface mode not supported.");
 
       const teamConfig = await teams.readConfig(safeTeamName);
       const cwd = params.cwd || process.cwd();
@@ -716,7 +716,7 @@ export default function (pi: ExtensionAPI) {
       try {
         const windowId = terminal.spawnWindow({ name: "team-lead", cwd, command: piCmd, env, teamName: safeTeamName });
         await teams.updateMember(safeTeamName, "team-lead", { windowId });
-        return { content: [{ type: "text", text: `Lead window spawned: ${windowId}` }], details: { windowId } };
+        return { content: [{ type: "text", text: `Lead separate surface spawned: ${windowId}` }], details: { windowId } };
       } catch (e) {
         throw new Error(`Failed: ${e}`);
       }
@@ -1103,7 +1103,7 @@ export default function (pi: ExtensionAPI) {
       predefined_team: Type.String({ description: "Name of the predefined team template from teams.yaml" }),
       cwd: Type.String({ description: "Working directory for spawned agents" }),
       default_model: Type.Optional(Type.String({ description: "Default model for agents without a specified model" })),
-      separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate OS windows instead of panes" })),
+      separate_windows: Type.Optional(Type.Boolean({ default: false, description: "Open teammates in separate window/tab surfaces instead of panes" })),
     }),
     async execute(toolCallId, params: any, signal, onUpdate, ctx) {
       const projectDir = ctx.cwd;
@@ -1155,7 +1155,7 @@ export default function (pi: ExtensionAPI) {
 
           const useSeparateWindow = params.separate_windows ?? config.separateWindows ?? false;
           if (useSeparateWindow && !terminal.supportsWindows()) {
-            throw new Error(`Separate windows mode is not supported in ${terminal.name}.`);
+            throw new Error(`Separate window/tab surface mode is not supported in ${terminal.name}.`);
           }
 
           const member: Member = {

--- a/src/adapters/herdr-adapter.test.ts
+++ b/src/adapters/herdr-adapter.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Herdr Adapter Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { HerdrAdapter } from "./herdr-adapter";
+import * as terminalAdapter from "../utils/terminal-adapter";
+
+describe("HerdrAdapter", () => {
+  let adapter: HerdrAdapter;
+  let mockExecCommand: ReturnType<typeof vi.spyOn>;
+  const originalEnv = {
+    HERDR_ENV: process.env.HERDR_ENV,
+    HERDR_SOCKET_PATH: process.env.HERDR_SOCKET_PATH,
+    HERDR_PANE_ID: process.env.HERDR_PANE_ID,
+    HERDR_TAB_ID: process.env.HERDR_TAB_ID,
+    HERDR_WORKSPACE_ID: process.env.HERDR_WORKSPACE_ID,
+    HERDR_BIN_PATH: process.env.HERDR_BIN_PATH,
+  };
+
+  beforeEach(() => {
+    adapter = new HerdrAdapter();
+    mockExecCommand = vi.spyOn(terminalAdapter, "execCommand");
+
+    process.env.HERDR_ENV = "1";
+    process.env.HERDR_SOCKET_PATH = "/tmp/herdr.sock";
+    process.env.HERDR_PANE_ID = "w1:p1";
+    process.env.HERDR_TAB_ID = "w1:t1";
+    process.env.HERDR_WORKSPACE_ID = "w1";
+    delete process.env.HERDR_BIN_PATH;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key as keyof typeof originalEnv];
+      else process.env[key as keyof typeof originalEnv] = value;
+    }
+  });
+
+  it("should have the correct name", () => {
+    expect(adapter.name).toBe("herdr");
+  });
+
+  it("should detect Herdr when the Herdr pane environment is present", () => {
+    expect(adapter.detect()).toBe(true);
+  });
+
+  it("should not detect when required Herdr variables are missing", () => {
+    delete process.env.HERDR_PANE_ID;
+    expect(adapter.detect()).toBe(false);
+  });
+
+  it("should spawn a teammate via herdr agent start and parse the pane ID", () => {
+    mockExecCommand.mockReturnValue({
+      stdout: JSON.stringify({
+        id: "cli:agent:start",
+        result: {
+          type: "agent_started",
+          agent: { pane_id: "w1:p2", tab_id: "w1:t1", workspace_id: "w1" },
+        },
+      }),
+      stderr: "",
+      status: 0,
+    });
+
+    const paneId = adapter.spawn({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi --model test/model",
+      env: {
+        PI_TEAM_NAME: "team-1",
+        PI_AGENT_NAME: "agent-1",
+        HERDR_PANE_ID: "w1:p1",
+        OTHER: "ignored",
+      },
+    });
+
+    expect(paneId).toBe("w1:p2");
+    expect(mockExecCommand).toHaveBeenCalledWith("herdr", ["pane", "get", "w1:p1"]);
+    expect(mockExecCommand).toHaveBeenCalledWith("herdr", [
+      "agent", "start", "agent-1",
+      "--cwd", "/tmp/project",
+      "--tab", "w1:t1",
+      "--split", "right",
+      "--no-focus",
+      "--env", "PI_TEAM_NAME=team-1",
+      "--env", "PI_AGENT_NAME=agent-1",
+      "--",
+      "sh", "-c", "pi --model test/model",
+    ]);
+  });
+
+  it("should resolve placement from the current pane instead of inherited tab env", () => {
+    process.env.HERDR_TAB_ID = "stale-tab";
+    process.env.HERDR_WORKSPACE_ID = "stale-workspace";
+    mockExecCommand
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({ result: { pane: { pane_id: "w1:p1", tab_id: "w2:t3", workspace_id: "w2" } } }),
+        stderr: "",
+        status: 0,
+      })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({ result: { agent: { pane_id: "w2:p4" } } }),
+        stderr: "",
+        status: 0,
+      });
+
+    adapter.spawn({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi",
+      env: { PI_TEAM_NAME: "team-1" },
+    });
+
+    expect(mockExecCommand).toHaveBeenNthCalledWith(1, "herdr", ["pane", "get", "w1:p1"]);
+    expect(mockExecCommand).toHaveBeenNthCalledWith(2, "herdr", expect.arrayContaining([
+      "--tab", "w2:t3",
+    ]));
+    expect(mockExecCommand.mock.calls[1][1]).not.toContain("stale-tab");
+  });
+
+  it("should fall back to workspace placement when pane lookup and tab env are unavailable", () => {
+    delete process.env.HERDR_TAB_ID;
+    mockExecCommand
+      .mockReturnValueOnce({ stdout: "", stderr: "not found", status: 1 })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({ result: { agent: { pane_id: "w1:p3" } } }),
+        stderr: "",
+        status: 0,
+      });
+
+    adapter.spawn({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi",
+      env: { PI_TEAM_NAME: "team-1" },
+    });
+
+    expect(mockExecCommand).toHaveBeenNthCalledWith(2, "herdr", expect.arrayContaining([
+      "--workspace", "w1",
+    ]));
+  });
+
+  it("should throw when Herdr spawn fails", () => {
+    mockExecCommand.mockReturnValue({ stdout: "", stderr: "boom", status: 1 });
+
+    expect(() => adapter.spawn({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi",
+      env: {},
+    })).toThrow(/herdr agent start failed/);
+  });
+
+  it("should close Herdr panes", () => {
+    mockExecCommand.mockReturnValue({ stdout: "", stderr: "", status: 0 });
+
+    adapter.kill("w1:p2");
+
+    expect(mockExecCommand).toHaveBeenCalledWith("herdr", ["pane", "close", "w1:p2"]);
+  });
+
+  it("should check whether Herdr panes are alive", () => {
+    mockExecCommand.mockReturnValueOnce({ stdout: "{}", stderr: "", status: 0 });
+    expect(adapter.isAlive("w1:p2")).toBe(true);
+
+    mockExecCommand.mockReturnValueOnce({ stdout: "", stderr: "not found", status: 1 });
+    expect(adapter.isAlive("w1:p3")).toBe(false);
+  });
+
+  it("should rename the current Herdr pane when setting the title", () => {
+    mockExecCommand.mockReturnValue({ stdout: "", stderr: "", status: 0 });
+
+    adapter.setTitle("team: agent-1");
+
+    expect(mockExecCommand).toHaveBeenCalledWith("herdr", ["pane", "rename", "w1:p1", "team: agent-1"]);
+  });
+
+  it("should advertise separate-window support as Herdr tabs", () => {
+    expect(adapter.supportsWindows()).toBe(true);
+  });
+
+  it("should spawn a teammate then move it into a new Herdr tab", () => {
+    process.env.HERDR_TAB_ID = "stale-tab";
+    process.env.HERDR_WORKSPACE_ID = "stale-workspace";
+
+    mockExecCommand
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({ result: { pane: { pane_id: "w1:p1", tab_id: "w1:t1", workspace_id: "w1" } } }),
+        stderr: "",
+        status: 0,
+      })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({
+          id: "cli:agent:start",
+          result: { agent: { pane_id: "w1:p2", tab_id: "w1:t1", workspace_id: "w1" } },
+        }),
+        stderr: "",
+        status: 0,
+      })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({ result: { pane: { pane_id: "w1:p1", tab_id: "w1:t1", workspace_id: "w1" } } }),
+        stderr: "",
+        status: 0,
+      })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({
+          id: "cli:pane:move",
+          result: {
+            move_result: {
+              created_tab: { tab_id: "w1:t2" },
+              pane: { pane_id: "w1:p2", tab_id: "w1:t2" },
+            },
+          },
+        }),
+        stderr: "",
+        status: 0,
+      });
+
+    const windowId = adapter.spawnWindow({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi",
+      env: { PI_TEAM_NAME: "team-1", PI_AGENT_NAME: "agent-1", HERDR_PANE_ID: "wrong" },
+      teamName: "team-1",
+    });
+
+    expect(windowId).toBe("w1:t2");
+    expect(mockExecCommand).toHaveBeenNthCalledWith(1, "herdr", ["pane", "get", "w1:p1"]);
+    expect(mockExecCommand).toHaveBeenNthCalledWith(2, "herdr", [
+      "agent", "start", "agent-1",
+      "--cwd", "/tmp/project",
+      "--tab", "w1:t1",
+      "--split", "right",
+      "--no-focus",
+      "--env", "PI_TEAM_NAME=team-1",
+      "--env", "PI_AGENT_NAME=agent-1",
+      "--",
+      "sh", "-c", "pi",
+    ]);
+    expect(mockExecCommand).toHaveBeenNthCalledWith(3, "herdr", ["pane", "get", "w1:p1"]);
+    expect(mockExecCommand).toHaveBeenNthCalledWith(4, "herdr", [
+      "pane", "move", "w1:p2",
+      "--new-tab",
+      "--workspace", "w1",
+      "--label", "team-1: agent-1",
+      "--no-focus",
+    ]);
+  });
+
+  it("should close the spawned pane if moving it into a new tab fails", () => {
+    mockExecCommand
+      .mockReturnValueOnce({ stdout: "", stderr: "not found", status: 1 })
+      .mockReturnValueOnce({
+        stdout: JSON.stringify({ result: { agent: { pane_id: "w1:p2" } } }),
+        stderr: "",
+        status: 0,
+      })
+      .mockReturnValueOnce({ stdout: "", stderr: "not found", status: 1 })
+      .mockReturnValueOnce({ stdout: "", stderr: "move failed", status: 1 })
+      .mockReturnValueOnce({ stdout: "", stderr: "", status: 0 });
+
+    expect(() => adapter.spawnWindow({
+      name: "agent-1",
+      cwd: "/tmp/project",
+      command: "pi",
+      env: {},
+    })).toThrow(/herdr pane move failed/);
+
+    expect(mockExecCommand).toHaveBeenLastCalledWith("herdr", ["pane", "close", "w1:p2"]);
+  });
+
+  it("should rename and close Herdr tab windows", () => {
+    mockExecCommand.mockReturnValue({ stdout: "", stderr: "", status: 0 });
+
+    adapter.setWindowTitle("w1:t2", "team: agent-1");
+    adapter.killWindow("w1:t2");
+
+    expect(mockExecCommand).toHaveBeenNthCalledWith(1, "herdr", ["tab", "rename", "w1:t2", "team: agent-1"]);
+    expect(mockExecCommand).toHaveBeenNthCalledWith(2, "herdr", ["tab", "close", "w1:t2"]);
+  });
+
+  it("should check whether Herdr tab windows are alive", () => {
+    mockExecCommand.mockReturnValueOnce({ stdout: "{}", stderr: "", status: 0 });
+    expect(adapter.isWindowAlive("w1:t2")).toBe(true);
+
+    mockExecCommand.mockReturnValueOnce({ stdout: "", stderr: "not found", status: 1 });
+    expect(adapter.isWindowAlive("w1:t3")).toBe(false);
+  });
+});

--- a/src/adapters/herdr-adapter.ts
+++ b/src/adapters/herdr-adapter.ts
@@ -1,0 +1,198 @@
+/**
+ * Herdr Terminal Adapter
+ *
+ * Implements the TerminalAdapter interface for Herdr (https://herdr.dev).
+ * Herdr is a terminal workspace manager with panes, tabs, and first-class
+ * coding-agent lifecycle integration.
+ */
+
+import { TerminalAdapter, SpawnOptions, execCommand } from "../utils/terminal-adapter";
+
+function parseJson(stdout: string): any | null {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+}
+
+export class HerdrAdapter implements TerminalAdapter {
+  readonly name = "herdr";
+
+  private herdrBin(): string {
+    return process.env.HERDR_BIN_PATH || "herdr";
+  }
+
+  private filteredEnv(options: SpawnOptions): Array<[string, string]> {
+    // Match the existing pi-teams adapter behavior: only explicitly inject
+    // pi-teams metadata. Do not pass inherited HERDR_* values from the lead
+    // pane; Herdr will set authoritative HERDR_PANE_ID/TAB_ID/WORKSPACE_ID
+    // values for the newly-created pane.
+    return Object.entries(options.env).filter(([key]) => key.startsWith("PI_"));
+  }
+
+  private envCliArgs(options: SpawnOptions): string[] {
+    return this.filteredEnv(options).flatMap(([key, value]) => ["--env", `${key}=${value}`]);
+  }
+
+  private currentPlacement(): { tabId?: string; workspaceId?: string } {
+    const paneId = process.env.HERDR_PANE_ID;
+    if (paneId) {
+      try {
+        const result = execCommand(this.herdrBin(), ["pane", "get", paneId]);
+        if (result.status === 0) {
+          const json = parseJson(result.stdout);
+          const pane = json?.result?.pane;
+          if (pane?.tab_id || pane?.workspace_id) {
+            return { tabId: pane.tab_id, workspaceId: pane.workspace_id };
+          }
+        }
+      } catch {
+        // Fall through to inherited environment below.
+      }
+    }
+
+    return {
+      tabId: process.env.HERDR_TAB_ID,
+      workspaceId: process.env.HERDR_WORKSPACE_ID,
+    };
+  }
+
+  detect(): boolean {
+    return (
+      process.env.HERDR_ENV === "1" &&
+      !!process.env.HERDR_SOCKET_PATH &&
+      !!process.env.HERDR_PANE_ID
+    );
+  }
+
+  spawn(options: SpawnOptions): string {
+    const args = [
+      "agent", "start", options.name,
+      "--cwd", options.cwd,
+    ];
+
+    const placement = this.currentPlacement();
+    if (placement.tabId) {
+      args.push("--tab", placement.tabId);
+    } else if (placement.workspaceId) {
+      args.push("--workspace", placement.workspaceId);
+    }
+
+    args.push(
+      "--split", "right",
+      "--no-focus",
+      ...this.envCliArgs(options),
+      "--",
+      "sh", "-c", options.command,
+    );
+
+    const result = execCommand(this.herdrBin(), args);
+    if (result.status !== 0) {
+      throw new Error(`herdr agent start failed with status ${result.status}: ${result.stderr || result.stdout}`);
+    }
+
+    const json = parseJson(result.stdout);
+    const paneId = json?.result?.agent?.pane_id || json?.result?.pane?.pane_id || json?.result?.pane_id;
+    if (!paneId) {
+      throw new Error(`herdr agent start returned unexpected output: ${result.stdout.trim()}`);
+    }
+
+    return paneId;
+  }
+
+  kill(paneId: string): void {
+    if (!paneId) return;
+
+    try {
+      execCommand(this.herdrBin(), ["pane", "close", paneId]);
+    } catch {
+      // Ignore errors during shutdown. The pane may already be closed.
+    }
+  }
+
+  isAlive(paneId: string): boolean {
+    if (!paneId) return false;
+
+    try {
+      const result = execCommand(this.herdrBin(), ["pane", "get", paneId]);
+      return result.status === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  setTitle(title: string): void {
+    const paneId = process.env.HERDR_PANE_ID;
+    if (!paneId) return;
+
+    try {
+      execCommand(this.herdrBin(), ["pane", "rename", paneId, title]);
+    } catch {
+      // Best-effort UI nicety only.
+    }
+  }
+
+  supportsWindows(): boolean {
+    // Herdr does not expose OS windows, but tabs are the Herdr-native isolated
+    // surface that best matches pi-teams' separate-window workflow.
+    return this.detect();
+  }
+
+  spawnWindow(options: SpawnOptions): string {
+    const paneId = this.spawn(options);
+    const title = options.teamName ? `${options.teamName}: ${options.name}` : options.name;
+    const args = ["pane", "move", paneId, "--new-tab", "--label", title, "--no-focus"];
+
+    const placement = this.currentPlacement();
+    if (placement.workspaceId) {
+      args.splice(4, 0, "--workspace", placement.workspaceId);
+    }
+
+    const result = execCommand(this.herdrBin(), args);
+    if (result.status !== 0) {
+      this.kill(paneId);
+      throw new Error(`herdr pane move failed with status ${result.status}: ${result.stderr || result.stdout}`);
+    }
+
+    const json = parseJson(result.stdout);
+    const tabId = json?.result?.move_result?.created_tab?.tab_id || json?.result?.tab?.tab_id || json?.result?.pane?.tab_id;
+    if (!tabId) {
+      this.kill(paneId);
+      throw new Error(`herdr pane move returned unexpected output: ${result.stdout.trim()}`);
+    }
+
+    return tabId;
+  }
+
+  setWindowTitle(windowId: string, title: string): void {
+    if (!windowId) return;
+
+    try {
+      execCommand(this.herdrBin(), ["tab", "rename", windowId, title]);
+    } catch {
+      // Best-effort only.
+    }
+  }
+
+  killWindow(windowId: string): void {
+    if (!windowId) return;
+
+    try {
+      execCommand(this.herdrBin(), ["tab", "close", windowId]);
+    } catch {
+      // Ignore errors during shutdown. The tab may already be closed.
+    }
+  }
+
+  isWindowAlive(windowId: string): boolean {
+    if (!windowId) return false;
+
+    try {
+      const result = execCommand(this.herdrBin(), ["tab", "get", windowId]);
+      return result.status === 0;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/adapters/terminal-registry.test.ts
+++ b/src/adapters/terminal-registry.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Terminal Registry Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { clearAdapterCache, getTerminalName } from "./terminal-registry";
+
+const ENV_KEYS = [
+  "HERDR_ENV",
+  "HERDR_SOCKET_PATH",
+  "HERDR_PANE_ID",
+  "HERDR_TAB_ID",
+  "HERDR_WORKSPACE_ID",
+  "TMUX",
+  "ZELLIJ",
+  "CMUX_SOCKET_PATH",
+  "CMUX_WORKSPACE_ID",
+  "TERM_PROGRAM",
+  "WEZTERM_PANE",
+] as const;
+
+describe("terminal registry", () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    clearAdapterCache();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    clearAdapterCache();
+  });
+
+  it("selects Herdr when Herdr pane environment is present", () => {
+    process.env.HERDR_ENV = "1";
+    process.env.HERDR_SOCKET_PATH = "/tmp/herdr.sock";
+    process.env.HERDR_PANE_ID = "w1:p1";
+
+    expect(getTerminalName()).toBe("herdr");
+  });
+
+  it("keeps Herdr priority when tmux-like environment is also present", () => {
+    process.env.HERDR_ENV = "1";
+    process.env.HERDR_SOCKET_PATH = "/tmp/herdr.sock";
+    process.env.HERDR_PANE_ID = "w1:p1";
+    process.env.TMUX = "/tmp/tmux-1000/default,123,0";
+
+    expect(getTerminalName()).toBe("herdr");
+  });
+});

--- a/src/adapters/terminal-registry.ts
+++ b/src/adapters/terminal-registry.ts
@@ -6,6 +6,7 @@
  */
 
 import { TerminalAdapter } from "../utils/terminal-adapter";
+import { HerdrAdapter } from "./herdr-adapter";
 import { TmuxAdapter } from "./tmux-adapter";
 import { ZellijAdapter } from "./zellij-adapter";
 import { CmuxAdapter } from "./cmux-adapter";
@@ -17,14 +18,18 @@ import { WindowsAdapter } from "./windows-adapter";
  * Available terminal adapters, ordered by priority
  *
  * Detection order (first match wins):
- * 1. tmux - if TMUX env is set
- * 2. Zellij - if ZELLIJ env is set and not in tmux
- * 3. cmux - if CMUX_SOCKET_PATH or CMUX_WORKSPACE_ID env is set
- * 4. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij/cmux
- * 5. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij/cmux
- * 6. Windows - if platform is win32 and not in tmux/zellij/cmux/iTerm2/WezTerm
+ * 1. Herdr - if HERDR_ENV/HERDR_PANE_ID/HERDR_SOCKET_PATH are set
+ * 2. tmux - if TMUX env is set
+ * 3. Zellij - if ZELLIJ env is set and not in tmux
+ * 4. cmux - if CMUX_SOCKET_PATH or CMUX_WORKSPACE_ID env is set
+ * 5. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij/cmux
+ * 6. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij/cmux
+ * 7. Windows - if platform is win32 and not in tmux/zellij/cmux/iTerm2/WezTerm
  */
 const adapters: TerminalAdapter[] = [
+  // Prefer Herdr when running inside a Herdr-managed pane. Herdr owns the
+  // visible workspace even when child shells expose tmux-like environment.
+  new HerdrAdapter(),
   new TmuxAdapter(),
   new ZellijAdapter(),
   new CmuxAdapter(),
@@ -42,12 +47,13 @@ let cachedAdapter: TerminalAdapter | null = null;
  * Detect and return the appropriate terminal adapter for the current environment.
  *
  * Detection order (first match wins):
- * 1. tmux - if TMUX env is set
- * 2. Zellij - if ZELLIJ env is set and not in tmux
- * 3. cmux - if CMUX_SOCKET_PATH or CMUX_WORKSPACE_ID env is set
- * 4. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij/cmux
- * 5. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij/cmux
- * 6. Windows - if platform is win32 and not in tmux/zellij/cmux/iTerm2/WezTerm
+ * 1. Herdr - if HERDR_ENV/HERDR_PANE_ID/HERDR_SOCKET_PATH are set
+ * 2. tmux - if TMUX env is set
+ * 3. Zellij - if ZELLIJ env is set and not in tmux
+ * 4. cmux - if CMUX_SOCKET_PATH or CMUX_WORKSPACE_ID env is set
+ * 5. iTerm2 - if TERM_PROGRAM=iTerm.app and not in tmux/zellij/cmux
+ * 6. WezTerm - if WEZTERM_PANE env is set and not in tmux/zellij/cmux
+ * 7. Windows - if platform is win32 and not in tmux/zellij/cmux/iTerm2/WezTerm
  *
  * @returns The detected terminal adapter, or null if none detected
  */
@@ -69,7 +75,7 @@ export function getTerminalAdapter(): TerminalAdapter | null {
 /**
  * Get a specific terminal adapter by name.
  *
- * @param name - The adapter name (e.g., "tmux", "zellij", "cmux", "iTerm2", "WezTerm", "Windows")
+ * @param name - The adapter name (e.g., "herdr", "tmux", "zellij", "cmux", "iTerm2", "WezTerm", "Windows")
  * @returns The adapter instance, or undefined if not found
  */
 export function getAdapterByName(name: string): TerminalAdapter | undefined {
@@ -109,9 +115,9 @@ export function hasTerminalAdapter(): boolean {
 }
 
 /**
- * Check if the current terminal supports spawning separate OS windows.
+ * Check if the current terminal supports spawning separate windows or terminal-native surfaces.
  *
- * @returns true if the detected terminal supports windows (iTerm2, WezTerm, Windows, cmux)
+ * @returns true if the detected terminal supports windows or equivalent isolated surfaces (Herdr tabs, iTerm2, WezTerm, Windows, cmux)
  */
 export function supportsWindows(): boolean {
   const adapter = getTerminalAdapter();

--- a/src/utils/terminal-adapter.ts
+++ b/src/utils/terminal-adapter.ts
@@ -76,45 +76,46 @@ export interface TerminalAdapter {
   setTitle(title: string): void;
 
   /**
-   * Check if this terminal supports spawning separate OS windows.
-   * Terminals like tmux and Zellij only support panes/tabs within a session.
+   * Check if this terminal supports spawning separate surfaces.
+   * Some adapters create true OS windows; others, such as Herdr, create
+   * terminal-native isolated surfaces such as tabs.
    * 
    * @returns true if spawnWindow() is supported
    */
   supportsWindows(): boolean;
 
   /**
-   * Spawn a new separate OS window with the given options.
+   * Spawn a new separate surface with the given options.
    * Only available if supportsWindows() returns true.
    * 
    * @param options - Spawn configuration
-   * @returns Window ID that can be used for subsequent operations
+   * @returns Surface ID that can be used for subsequent operations
    * @throws Error if spawn fails or not supported
    */
   spawnWindow(options: SpawnOptions): string;
 
   /**
-   * Set the title of a specific window.
-   * Used for identifying windows in the OS window manager.
+   * Set the title of a specific separate surface.
+   * Used for identifying windows/tabs in the terminal UI.
    * 
-   * @param windowId - The window ID returned from spawnWindow()
+   * @param windowId - The surface ID returned from spawnWindow()
    * @param title - The title to set
    */
   setWindowTitle(windowId: string, title: string): void;
 
   /**
-   * Kill/terminate a window.
-   * Should be idempotent - no error if window doesn't exist.
+   * Kill/terminate a separate surface.
+   * Should be idempotent - no error if the surface doesn't exist.
    * 
-   * @param windowId - The window ID returned from spawnWindow()
+   * @param windowId - The surface ID returned from spawnWindow()
    */
   killWindow(windowId: string): void;
 
   /**
-   * Check if a window is still alive/active.
+   * Check if a separate surface is still alive/active.
    * 
-   * @param windowId - The window ID returned from spawnWindow()
-   * @returns true if window exists and is active
+   * @param windowId - The surface ID returned from spawnWindow()
+   * @returns true if surface exists and is active
    */
   isWindowAlive(windowId: string): boolean;
 }


### PR DESCRIPTION
## Summary

Adds Herdr support to pi-teams through a new terminal adapter.

- Detects Herdr-managed panes via `HERDR_ENV`, `HERDR_SOCKET_PATH`, and `HERDR_PANE_ID`.
- Spawns teammates with `herdr agent start`.
- Maps separate-window mode to separate Herdr tabs.
- Resolves live Herdr tab/workspace placement from `herdr pane get $HERDR_PANE_ID` so moved panes do not reuse stale inherited Herdr environment.
- Registers Herdr ahead of tmux/Zellij/etc. because Herdr owns the visible workspace when running inside a Herdr pane.
- Updates user-facing wording from OS-window-only language to separate window/tab surfaces where appropriate.
- Adds adapter and registry-priority tests.

## Validation

Ran in a clean upstream worktree:

```bash
npx --yes vitest@4.0.18 run src/adapters/herdr-adapter.test.ts src/adapters/terminal-registry.test.ts
# 2 files, 17 tests passed

npx --yes vitest@4.0.18 run
# 16 files, 146 tests passed
```

Also ran live Herdr smoke tests against this branch:

- pane mode: spawned a Herdr pane, observed output, verified child `HERDR_PANE_ID` matched the spawned pane and differed from the parent.
- separate-window/tab mode: spawned and moved a teammate into a new Herdr tab with intentionally stale inherited `HERDR_TAB_ID`/`HERDR_WORKSPACE_ID`; verified output and live placement.
- cleanup check: no leftover Herdr smoke agents.
